### PR TITLE
Error when destination path starts with '/'

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ module.exports = function(destination, opts) {
 
     function createDestination(destination)
     {
-        var folders = destination.split('/').filter(Boolean),
+        var folders = destination.split('/'),
             path = [],
             l = folders.length,
             i = 0;
@@ -61,7 +61,7 @@ module.exports = function(destination, opts) {
         for (; i < l; i++) {
             path.push(folders[i]);
 
-            if (!fs.existsSync(path.join('/'))) {
+            if (folders[i] !== "" && !fs.existsSync(path.join('/'))) {
                 try {
                     fs.mkdirSync(path.join('/'));
                 } catch (error) {

--- a/index.js
+++ b/index.js
@@ -26,9 +26,9 @@ module.exports = function(destination, opts) {
                 rel = rel.substring(rel.indexOf('/') + 1);
             }
         }
-        
+
         fileDestination = destination + '/' + rel;
-        
+
         // Make sure destination exists
          if (!fs.existsSync(fileDestination)) {
              createDestination(fileDestination.substr(0, fileDestination.lastIndexOf('/')));
@@ -39,10 +39,10 @@ module.exports = function(destination, opts) {
             if (error) {
                 throw new PluginError('gulp-copy', 'Could not copy file <' +  file.path + '>: ' + error.message);
             }
-            
+
             // Update path for file so this path is used later on
             file.path = fileDestination;
-            self.emit('data', file); 
+            self.emit('data', file);
         });
     }
 
@@ -50,7 +50,7 @@ module.exports = function(destination, opts) {
     {
         this.emit('end');
     }
-    
+
     function createDestination(destination)
     {
         var folders = destination.split('/'),
@@ -71,30 +71,30 @@ module.exports = function(destination, opts) {
         }
     }
 
-    function copyFile(source, target, cb) 
+    function copyFile(source, target, cb)
     {
         var cbCalled = false,
             rd = fs.createReadStream(source),
             wr;
-  
+
             rd.on("error", function(err) {
                 done(err);
             });
-            
-            
+
+
         wr = fs.createWriteStream(target);
-  
+
         wr.on("error", function(err) {
             done(err);
         });
-  
+
         wr.on("close", function(ex) {
             done();
         });
-  
+
         rd.pipe(wr);
 
-        function done(err) 
+        function done(err)
         {
             if (!cbCalled) {
                 cb(err);

--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ module.exports = function(destination, opts) {
 
     function createDestination(destination)
     {
-        var folders = destination.split('/'),
+        var folders = destination.split('/').filter(Boolean),
             path = [],
             l = folders.length,
             i = 0;


### PR DESCRIPTION
If the output path starts with '/', there's an error thrown:

`Could not create destination <...>: ENOENT: no such file or directory, mkdir ''`

This can be prevented by jumping over the directory creation if folder[i] is empty.

(I removed unnecessary whitespace too)