### PR TITLE
Replace deprecated dependency gulp-util

### DIFF
--- a/lib/gulp-copy.js
+++ b/lib/gulp-copy.js
@@ -3,7 +3,7 @@
 var through = require('through2');
 var path = require('path');
 var fs = require('fs');
-var PluginError = require('gulp-util').PluginError;
+var PluginError = require('plugin-error');
 
 /**
  * gulp copy method

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "gulp-copy",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -27,27 +27,27 @@
                 }
             }
         },
-        "ajv": {
-            "version": "4.11.8",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-            "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-            "dev": true,
-            "requires": {
-                "co": "4.6.0",
-                "json-stable-stringify": "1.0.1"
-            }
-        },
         "ajv-keywords": {
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
             "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
             "dev": true
         },
-        "ansi-escapes": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-            "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
-            "dev": true
+        "ansi-cyan": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-cyan/-/ansi-cyan-0.1.1.tgz",
+            "integrity": "sha1-U4rlKK+JgvKK4w2G8vF0VtJgmHM=",
+            "requires": {
+                "ansi-wrap": "0.1.0"
+            }
+        },
+        "ansi-red": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-red/-/ansi-red-0.1.1.tgz",
+            "integrity": "sha1-jGOPnRCAgAo1PJwoyKgcpHBdlGw=",
+            "requires": {
+                "ansi-wrap": "0.1.0"
+            }
         },
         "ansi-regex": {
             "version": "2.1.1",
@@ -58,6 +58,11 @@
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
             "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+        },
+        "ansi-wrap": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
+            "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768="
         },
         "archy": {
             "version": "1.0.0",
@@ -85,6 +90,11 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
             "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+        },
+        "arr-union": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-2.1.0.tgz",
+            "integrity": "sha1-IPnqtexw9cfSFbEHexw5Fh0pLH0="
         },
         "array-differ": {
             "version": "1.0.0",
@@ -199,15 +209,6 @@
             "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
             "dev": true
         },
-        "cli-cursor": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-            "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
-            "dev": true,
-            "requires": {
-                "restore-cursor": "1.0.1"
-            }
-        },
         "cli-width": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
@@ -228,12 +229,6 @@
             "version": "4.6.0",
             "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
             "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-            "dev": true
-        },
-        "code-point-at": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-            "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
             "dev": true
         },
         "coffee-script": {
@@ -331,15 +326,6 @@
                         "yallist": "2.1.2"
                     }
                 }
-            }
-        },
-        "d": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
-            "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
-            "dev": true,
-            "requires": {
-                "es5-ext": "0.10.27"
             }
         },
         "dateformat": {
@@ -440,92 +426,10 @@
                 "once": "1.3.3"
             }
         },
-        "es5-ext": {
-            "version": "0.10.27",
-            "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.27.tgz",
-            "integrity": "sha512-3KXJRYzKXTd7xfFy5uZsJCXue55fAYQ035PRjyYk2PicllxIwcW9l3AbM/eGaw3vgVAUW4tl4xg9AXDEI6yw0w==",
-            "dev": true,
-            "requires": {
-                "es6-iterator": "2.0.1",
-                "es6-symbol": "3.1.1"
-            }
-        },
-        "es6-iterator": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
-            "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
-            "dev": true,
-            "requires": {
-                "d": "1.0.0",
-                "es5-ext": "0.10.27",
-                "es6-symbol": "3.1.1"
-            }
-        },
-        "es6-map": {
-            "version": "0.1.5",
-            "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
-            "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
-            "dev": true,
-            "requires": {
-                "d": "1.0.0",
-                "es5-ext": "0.10.27",
-                "es6-iterator": "2.0.1",
-                "es6-set": "0.1.5",
-                "es6-symbol": "3.1.1",
-                "event-emitter": "0.3.5"
-            }
-        },
-        "es6-set": {
-            "version": "0.1.5",
-            "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
-            "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
-            "dev": true,
-            "requires": {
-                "d": "1.0.0",
-                "es5-ext": "0.10.27",
-                "es6-iterator": "2.0.1",
-                "es6-symbol": "3.1.1",
-                "event-emitter": "0.3.5"
-            }
-        },
-        "es6-symbol": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
-            "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
-            "dev": true,
-            "requires": {
-                "d": "1.0.0",
-                "es5-ext": "0.10.27"
-            }
-        },
-        "es6-weak-map": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
-            "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
-            "dev": true,
-            "requires": {
-                "d": "1.0.0",
-                "es5-ext": "0.10.27",
-                "es6-iterator": "2.0.1",
-                "es6-symbol": "3.1.1"
-            }
-        },
         "escape-string-regexp": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
             "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-        },
-        "escope": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
-            "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
-            "dev": true,
-            "requires": {
-                "es6-map": "0.1.5",
-                "es6-weak-map": "2.0.2",
-                "esrecurse": "4.2.0",
-                "estraverse": "4.2.0"
-            }
         },
         "eslint": {
             "version": "4.4.1",
@@ -871,22 +775,6 @@
             "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
             "dev": true
         },
-        "event-emitter": {
-            "version": "0.3.5",
-            "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
-            "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
-            "dev": true,
-            "requires": {
-                "d": "1.0.0",
-                "es5-ext": "0.10.27"
-            }
-        },
-        "exit-hook": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
-            "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
-            "dev": true
-        },
         "expand-brackets": {
             "version": "0.1.5",
             "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
@@ -915,6 +803,21 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
             "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+        },
+        "extend-shallow": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz",
+            "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
+            "requires": {
+                "kind-of": "1.1.0"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
+                    "integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ="
+                }
+            }
         },
         "external-editor": {
             "version": "2.0.4",
@@ -955,24 +858,6 @@
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
             "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
             "dev": true
-        },
-        "figures": {
-            "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-            "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-            "dev": true,
-            "requires": {
-                "escape-string-regexp": "1.0.5",
-                "object-assign": "4.1.1"
-            },
-            "dependencies": {
-                "object-assign": {
-                    "version": "4.1.1",
-                    "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-                    "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-                    "dev": true
-                }
-            }
         },
         "file-entry-cache": {
             "version": "2.0.0",
@@ -1157,21 +1042,6 @@
             "integrity": "sha1-QLcJU30k0dRXZ9takIaJ3+aaxE8=",
             "requires": {
                 "globule": "0.1.0"
-            }
-        },
-        "generate-function": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-            "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
-            "dev": true
-        },
-        "generate-object-property": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-            "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-            "dev": true,
-            "requires": {
-                "is-property": "1.0.2"
             }
         },
         "glob": {
@@ -1507,35 +1377,6 @@
             "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
             "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4="
         },
-        "inquirer": {
-            "version": "0.12.0",
-            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
-            "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
-            "dev": true,
-            "requires": {
-                "ansi-escapes": "1.4.0",
-                "ansi-regex": "2.1.1",
-                "chalk": "1.1.3",
-                "cli-cursor": "1.0.2",
-                "cli-width": "2.1.0",
-                "figures": "1.7.0",
-                "lodash": "4.17.4",
-                "readline2": "1.0.1",
-                "run-async": "0.1.0",
-                "rx-lite": "3.1.2",
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1",
-                "through": "2.3.8"
-            },
-            "dependencies": {
-                "lodash": {
-                    "version": "4.17.4",
-                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-                    "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-                    "dev": true
-                }
-            }
-        },
         "interpret": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
@@ -1578,33 +1419,12 @@
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
             "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
         },
-        "is-fullwidth-code-point": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-            "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-            "dev": true,
-            "requires": {
-                "number-is-nan": "1.0.1"
-            }
-        },
         "is-glob": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
             "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
             "requires": {
                 "is-extglob": "1.0.0"
-            }
-        },
-        "is-my-json-valid": {
-            "version": "2.16.0",
-            "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
-            "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
-            "dev": true,
-            "requires": {
-                "generate-function": "2.0.0",
-                "generate-object-property": "1.2.0",
-                "jsonpointer": "4.0.1",
-                "xtend": "4.0.1"
             }
         },
         "is-number": {
@@ -1668,12 +1488,6 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
             "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
-            "dev": true
-        },
-        "is-property": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-            "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
             "dev": true
         },
         "is-relative": {
@@ -1806,144 +1620,6 @@
                 }
             }
         },
-        "js-styleguide": {
-            "version": "git://github.com/klaascuvelier/js-styleguide.git#ced1454f7dc11d49cf4bd3a7d525b3d60bcab234",
-            "dev": true,
-            "requires": {
-                "eslint": "3.0.1"
-            },
-            "dependencies": {
-                "doctrine": {
-                    "version": "1.5.0",
-                    "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
-                    "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
-                    "dev": true,
-                    "requires": {
-                        "esutils": "2.0.2",
-                        "isarray": "1.0.0"
-                    }
-                },
-                "eslint": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/eslint/-/eslint-3.0.1.tgz",
-                    "integrity": "sha1-/xLq/cBOpx0XOgmdRlihNucVeTQ=",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "1.1.3",
-                        "concat-stream": "1.6.0",
-                        "debug": "2.6.8",
-                        "doctrine": "1.5.0",
-                        "es6-map": "0.1.5",
-                        "escope": "3.6.0",
-                        "espree": "3.5.0",
-                        "estraverse": "4.2.0",
-                        "esutils": "2.0.2",
-                        "file-entry-cache": "1.3.1",
-                        "glob": "7.1.2",
-                        "globals": "9.18.0",
-                        "ignore": "3.3.3",
-                        "imurmurhash": "0.1.4",
-                        "inquirer": "0.12.0",
-                        "is-my-json-valid": "2.16.0",
-                        "is-resolvable": "1.0.0",
-                        "js-yaml": "3.9.1",
-                        "json-stable-stringify": "1.0.1",
-                        "levn": "0.3.0",
-                        "lodash": "4.17.4",
-                        "mkdirp": "0.5.1",
-                        "optionator": "0.8.2",
-                        "path-is-inside": "1.0.2",
-                        "pluralize": "1.2.1",
-                        "progress": "1.1.8",
-                        "require-uncached": "1.0.3",
-                        "shelljs": "0.6.1",
-                        "strip-bom": "3.0.0",
-                        "strip-json-comments": "1.0.4",
-                        "table": "3.8.3",
-                        "text-table": "0.2.0",
-                        "user-home": "2.0.0"
-                    }
-                },
-                "file-entry-cache": {
-                    "version": "1.3.1",
-                    "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-1.3.1.tgz",
-                    "integrity": "sha1-RMYepgeuS+nBQC9B9EJwy/4zT/g=",
-                    "dev": true,
-                    "requires": {
-                        "flat-cache": "1.2.2",
-                        "object-assign": "4.1.1"
-                    }
-                },
-                "glob": {
-                    "version": "7.1.2",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-                    "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-                    "dev": true,
-                    "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.3.3",
-                        "path-is-absolute": "1.0.1"
-                    }
-                },
-                "isarray": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-                    "dev": true
-                },
-                "lodash": {
-                    "version": "4.17.4",
-                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-                    "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-                    "dev": true
-                },
-                "minimatch": {
-                    "version": "3.0.4",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-                    "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-                    "dev": true,
-                    "requires": {
-                        "brace-expansion": "1.1.8"
-                    }
-                },
-                "object-assign": {
-                    "version": "4.1.1",
-                    "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-                    "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-                    "dev": true
-                },
-                "shelljs": {
-                    "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.6.1.tgz",
-                    "integrity": "sha1-7GIRvtGSBEIIj+D3Cyg3Iy7SyKg=",
-                    "dev": true
-                },
-                "strip-bom": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-                    "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-                    "dev": true
-                },
-                "strip-json-comments": {
-                    "version": "1.0.4",
-                    "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
-                    "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
-                    "dev": true
-                },
-                "user-home": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
-                    "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
-                    "dev": true,
-                    "requires": {
-                        "os-homedir": "1.0.2"
-                    }
-                }
-            }
-        },
         "js-tokens": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
@@ -1985,12 +1661,6 @@
             "version": "0.0.0",
             "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
             "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-            "dev": true
-        },
-        "jsonpointer": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-            "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
             "dev": true
         },
         "kind-of": {
@@ -2228,12 +1898,6 @@
                 "duplexer2": "0.0.2"
             }
         },
-        "mute-stream": {
-            "version": "0.0.5",
-            "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
-            "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
-            "dev": true
-        },
         "natives": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.0.tgz",
@@ -2252,12 +1916,6 @@
             "requires": {
                 "remove-trailing-separator": "1.0.2"
             }
-        },
-        "number-is-nan": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-            "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-            "dev": true
         },
         "object-assign": {
             "version": "3.0.0",
@@ -2314,12 +1972,6 @@
             "requires": {
                 "wrappy": "1.0.2"
             }
-        },
-        "onetime": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-            "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
-            "dev": true
         },
         "optionator": {
             "version": "0.8.2",
@@ -2438,11 +2090,33 @@
                 "pinkie": "2.0.4"
             }
         },
-        "pluralize": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
-            "integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=",
-            "dev": true
+        "plugin-error": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-0.1.2.tgz",
+            "integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
+            "requires": {
+                "ansi-cyan": "0.1.1",
+                "ansi-red": "0.1.1",
+                "arr-diff": "1.1.0",
+                "arr-union": "2.1.0",
+                "extend-shallow": "1.1.4"
+            },
+            "dependencies": {
+                "arr-diff": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.1.0.tgz",
+                    "integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
+                    "requires": {
+                        "arr-flatten": "1.1.0",
+                        "array-slice": "0.2.3"
+                    }
+                },
+                "array-slice": {
+                    "version": "0.2.3",
+                    "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
+                    "integrity": "sha1-3Tz7gO15c6dRF82sabC5nshhhvU="
+                }
+            }
         },
         "prelude-ls": {
             "version": "1.1.2",
@@ -2464,12 +2138,6 @@
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
             "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
-        },
-        "progress": {
-            "version": "1.1.8",
-            "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
-            "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
-            "dev": true
         },
         "pseudomap": {
             "version": "1.0.2",
@@ -2523,17 +2191,6 @@
                 "inherits": "2.0.3",
                 "isarray": "0.0.1",
                 "string_decoder": "0.10.31"
-            }
-        },
-        "readline2": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
-            "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
-            "dev": true,
-            "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "mute-stream": "0.0.5"
             }
         },
         "rechoir": {
@@ -2612,16 +2269,6 @@
             "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
             "dev": true
         },
-        "restore-cursor": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-            "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
-            "dev": true,
-            "requires": {
-                "exit-hook": "1.1.1",
-                "onetime": "1.1.0"
-            }
-        },
         "rimraf": {
             "version": "2.6.1",
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
@@ -2654,15 +2301,6 @@
                         "brace-expansion": "1.1.8"
                     }
                 }
-            }
-        },
-        "run-async": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
-            "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
-            "dev": true,
-            "requires": {
-                "once": "1.3.3"
             }
         },
         "rx-lite": {
@@ -2748,17 +2386,6 @@
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
             "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         },
-        "string-width": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-            "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-            "dev": true,
-            "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
-            }
-        },
         "strip-ansi": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
@@ -2786,59 +2413,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
             "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-        },
-        "table": {
-            "version": "3.8.3",
-            "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
-            "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
-            "dev": true,
-            "requires": {
-                "ajv": "4.11.8",
-                "ajv-keywords": "1.5.1",
-                "chalk": "1.1.3",
-                "lodash": "4.17.4",
-                "slice-ansi": "0.0.4",
-                "string-width": "2.1.1"
-            },
-            "dependencies": {
-                "ansi-regex": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-                    "dev": true
-                },
-                "is-fullwidth-code-point": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-                    "dev": true
-                },
-                "lodash": {
-                    "version": "4.17.4",
-                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-                    "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-                    "dev": true
-                },
-                "string-width": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-                    "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-                    "dev": true,
-                    "requires": {
-                        "is-fullwidth-code-point": "2.0.0",
-                        "strip-ansi": "4.0.0"
-                    }
-                },
-                "strip-ansi": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "3.0.0"
-                    }
-                }
-            }
         },
         "text-table": {
             "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     },
     "dependencies": {
         "gulp": "^3.9.1",
-        "gulp-util": "^3.0.8",
+        "plugin-error": "^0.1.2",
         "through2": "^2.0.3"
     },
     "homepage": "https://github.com/klaascuvelier/gulp-copy"


### PR DESCRIPTION
Replace deprecated dependency gulp-util

[`gulp-util`](https://www.npmjs.com/package/gulp-util) has been deprecated recently. Continuing to use this dependency may prevent the use of your library with the recently released version 4 of Gulp, **it is important to replace `gulp-util`**.

The [README.md](https://github.com/gulpjs/gulp-util) lists alternatives for all the components so a simple replacement should be enough.

Your package is popular but still relying on `gulp-util`, it would be good to publish a fixed version to npm as soon as possible.

See:
- https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5
- https://github.com/gulpjs/gulp-util/issues/143

Closes #24 
  