### PR TITLE
Upgrade Gulp to v4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -396,10 +396,26 @@
             "integrity": "sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo=",
             "dev": true
         },
+        "ansi-colors": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
+            "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
+            "requires": {
+                "ansi-wrap": "^0.1.0"
+            }
+        },
         "ansi-cyan": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/ansi-cyan/-/ansi-cyan-0.1.1.tgz",
             "integrity": "sha1-U4rlKK+JgvKK4w2G8vF0VtJgmHM=",
+            "requires": {
+                "ansi-wrap": "0.1.0"
+            }
+        },
+        "ansi-gray": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
+            "integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
             "requires": {
                 "ansi-wrap": "0.1.0"
             }
@@ -420,7 +436,8 @@
         "ansi-styles": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-            "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+            "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+            "dev": true
         },
         "ansi-wrap": {
             "version": "0.1.0",
@@ -431,7 +448,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
             "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
-            "dev": true,
             "requires": {
                 "micromatch": "^3.1.4",
                 "normalize-path": "^2.1.1"
@@ -440,20 +456,17 @@
                 "arr-diff": {
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-                    "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
-                    "dev": true
+                    "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
                 },
                 "array-unique": {
                     "version": "0.3.2",
                     "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-                    "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-                    "dev": true
+                    "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
                 },
                 "braces": {
                     "version": "2.3.2",
                     "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
                     "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-                    "dev": true,
                     "requires": {
                         "arr-flatten": "^1.1.0",
                         "array-unique": "^0.3.2",
@@ -471,7 +484,6 @@
                             "version": "2.0.1",
                             "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                            "dev": true,
                             "requires": {
                                 "is-extendable": "^0.1.0"
                             }
@@ -482,7 +494,6 @@
                     "version": "2.6.9",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
                     "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-                    "dev": true,
                     "requires": {
                         "ms": "2.0.0"
                     }
@@ -491,7 +502,6 @@
                     "version": "2.1.4",
                     "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
                     "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
-                    "dev": true,
                     "requires": {
                         "debug": "^2.3.3",
                         "define-property": "^0.2.5",
@@ -506,7 +516,6 @@
                             "version": "0.2.5",
                             "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
                             "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-                            "dev": true,
                             "requires": {
                                 "is-descriptor": "^0.1.0"
                             }
@@ -515,7 +524,6 @@
                             "version": "2.0.1",
                             "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                            "dev": true,
                             "requires": {
                                 "is-extendable": "^0.1.0"
                             }
@@ -524,7 +532,6 @@
                             "version": "0.1.6",
                             "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
                             "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-                            "dev": true,
                             "requires": {
                                 "kind-of": "^3.0.2"
                             },
@@ -533,7 +540,6 @@
                                     "version": "3.2.2",
                                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                                    "dev": true,
                                     "requires": {
                                         "is-buffer": "^1.1.5"
                                     }
@@ -544,7 +550,6 @@
                             "version": "0.1.4",
                             "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
                             "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-                            "dev": true,
                             "requires": {
                                 "kind-of": "^3.0.2"
                             },
@@ -553,7 +558,6 @@
                                     "version": "3.2.2",
                                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                                    "dev": true,
                                     "requires": {
                                         "is-buffer": "^1.1.5"
                                     }
@@ -564,7 +568,6 @@
                             "version": "0.1.6",
                             "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
                             "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-                            "dev": true,
                             "requires": {
                                 "is-accessor-descriptor": "^0.1.6",
                                 "is-data-descriptor": "^0.1.4",
@@ -574,8 +577,7 @@
                         "kind-of": {
                             "version": "5.1.0",
                             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-                            "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-                            "dev": true
+                            "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
                         }
                     }
                 },
@@ -583,7 +585,6 @@
                     "version": "3.0.2",
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
                     "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
-                    "dev": true,
                     "requires": {
                         "assign-symbols": "^1.0.0",
                         "is-extendable": "^1.0.1"
@@ -593,7 +594,6 @@
                             "version": "1.0.1",
                             "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
                             "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-                            "dev": true,
                             "requires": {
                                 "is-plain-object": "^2.0.4"
                             }
@@ -604,7 +604,6 @@
                     "version": "2.0.4",
                     "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
                     "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
-                    "dev": true,
                     "requires": {
                         "array-unique": "^0.3.2",
                         "define-property": "^1.0.0",
@@ -620,7 +619,6 @@
                             "version": "1.0.0",
                             "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
                             "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-                            "dev": true,
                             "requires": {
                                 "is-descriptor": "^1.0.0"
                             }
@@ -629,7 +627,6 @@
                             "version": "2.0.1",
                             "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                            "dev": true,
                             "requires": {
                                 "is-extendable": "^0.1.0"
                             }
@@ -640,7 +637,6 @@
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
                     "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-                    "dev": true,
                     "requires": {
                         "extend-shallow": "^2.0.1",
                         "is-number": "^3.0.0",
@@ -652,7 +648,6 @@
                             "version": "2.0.1",
                             "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                            "dev": true,
                             "requires": {
                                 "is-extendable": "^0.1.0"
                             }
@@ -663,7 +658,6 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-                    "dev": true,
                     "requires": {
                         "kind-of": "^6.0.0"
                     }
@@ -672,7 +666,6 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-                    "dev": true,
                     "requires": {
                         "kind-of": "^6.0.0"
                     }
@@ -681,7 +674,6 @@
                     "version": "1.0.2",
                     "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-                    "dev": true,
                     "requires": {
                         "is-accessor-descriptor": "^1.0.0",
                         "is-data-descriptor": "^1.0.0",
@@ -692,7 +684,6 @@
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-                    "dev": true,
                     "requires": {
                         "kind-of": "^3.0.2"
                     },
@@ -701,7 +692,6 @@
                             "version": "3.2.2",
                             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                            "dev": true,
                             "requires": {
                                 "is-buffer": "^1.1.5"
                             }
@@ -711,20 +701,17 @@
                 "isobject": {
                     "version": "3.0.1",
                     "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-                    "dev": true
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
                 },
                 "kind-of": {
                     "version": "6.0.2",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-                    "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-                    "dev": true
+                    "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
                 },
                 "micromatch": {
                     "version": "3.1.10",
                     "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
                     "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-                    "dev": true,
                     "requires": {
                         "arr-diff": "^4.0.0",
                         "array-unique": "^0.3.2",
@@ -745,11 +732,18 @@
                     "version": "1.3.0",
                     "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
                     "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
-                    "dev": true,
                     "requires": {
                         "isobject": "^3.0.1"
                     }
                 }
+            }
+        },
+        "append-buffer": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/append-buffer/-/append-buffer-1.0.2.tgz",
+            "integrity": "sha1-2CIM9GYIFSXv6lBhTz3mUU36WPE=",
+            "requires": {
+                "buffer-equal": "^1.0.0"
             }
         },
         "aproba": {
@@ -783,11 +777,16 @@
             }
         },
         "arr-diff": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-            "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+            "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+        },
+        "arr-filter": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/arr-filter/-/arr-filter-1.1.2.tgz",
+            "integrity": "sha1-Q/3d0JHo7xGqTEXZzcGOLf8XEe4=",
             "requires": {
-                "arr-flatten": "^1.0.1"
+                "make-iterator": "^1.0.0"
             }
         },
         "arr-flatten": {
@@ -795,15 +794,18 @@
             "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
             "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
         },
+        "arr-map": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/arr-map/-/arr-map-2.0.2.tgz",
+            "integrity": "sha1-Onc0X/wc814qkYJWAfnljy4kysQ=",
+            "requires": {
+                "make-iterator": "^1.0.0"
+            }
+        },
         "arr-union": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-2.1.0.tgz",
             "integrity": "sha1-IPnqtexw9cfSFbEHexw5Fh0pLH0="
-        },
-        "array-differ": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
-            "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE="
         },
         "array-each": {
             "version": "1.0.1",
@@ -826,10 +828,58 @@
                 "es-abstract": "^1.7.0"
             }
         },
+        "array-initial": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/array-initial/-/array-initial-1.1.0.tgz",
+            "integrity": "sha1-L6dLJnOTccOUe9enrcc74zSz15U=",
+            "requires": {
+                "array-slice": "^1.0.0",
+                "is-number": "^4.0.0"
+            },
+            "dependencies": {
+                "is-number": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+                    "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
+                }
+            }
+        },
+        "array-last": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/array-last/-/array-last-1.3.0.tgz",
+            "integrity": "sha512-eOCut5rXlI6aCOS7Z7kCplKRKyiFQ6dHFBem4PwlwKeNFk2/XxTrhRh5T9PyaEWGy/NHTZWbY+nsZlNFJu9rYg==",
+            "requires": {
+                "is-number": "^4.0.0"
+            },
+            "dependencies": {
+                "is-number": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+                    "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
+                }
+            }
+        },
         "array-slice": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-1.1.0.tgz",
+            "integrity": "sha512-B1qMD3RBP7O8o0H2KbrXDyB0IccejMF15+87Lvlor12ONPRHP6gTjXMNkt/d3ZuOGbAe66hFmaCfECI24Ufp6w=="
+        },
+        "array-sort": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-1.0.0.tgz",
-            "integrity": "sha1-5zA08A3MH0CHYAj9IP6ud71LfC8="
+            "resolved": "https://registry.npmjs.org/array-sort/-/array-sort-1.0.0.tgz",
+            "integrity": "sha512-ihLeJkonmdiAsD7vpgN3CRcx2J2S0TiYW+IS/5zHBI7mKUq3ySvBdzzBfD236ubDBQFiiyG3SWCPc+msQ9KoYg==",
+            "requires": {
+                "default-compare": "^1.0.0",
+                "get-value": "^2.0.6",
+                "kind-of": "^5.0.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+                    "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+                }
+            }
         },
         "array-union": {
             "version": "1.0.2",
@@ -843,12 +893,13 @@
         "array-uniq": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-            "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
+            "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+            "dev": true
         },
         "array-unique": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-            "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+            "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
         },
         "arrify": {
             "version": "1.0.1",
@@ -896,8 +947,7 @@
         "assign-symbols": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
-            "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
-            "dev": true
+            "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
         },
         "ast-types-flow": {
             "version": "0.0.7",
@@ -905,17 +955,34 @@
             "integrity": "sha1-9wtzXGvKGlycItmCw+Oef+ujva0=",
             "dev": true
         },
+        "async-done": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/async-done/-/async-done-1.3.1.tgz",
+            "integrity": "sha512-R1BaUeJ4PMoLNJuk+0tLJgjmEqVsdN118+Z8O+alhnQDQgy0kmD5Mqi0DNEmMx2LM0Ed5yekKu+ZXYvIHceicg==",
+            "requires": {
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.2",
+                "process-nextick-args": "^1.0.7",
+                "stream-exhaust": "^1.0.1"
+            }
+        },
         "async-each": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
-            "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
-            "dev": true
+            "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0="
+        },
+        "async-settle": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/async-settle/-/async-settle-1.0.0.tgz",
+            "integrity": "sha1-HQqRS7Aldb7IqPOnTlCA9yssDGs=",
+            "requires": {
+                "async-done": "^1.2.2"
+            }
         },
         "atob": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.1.tgz",
-            "integrity": "sha1-ri1acpR38onWDdf5amMUoi3Wwio=",
-            "dev": true
+            "integrity": "sha1-ri1acpR38onWDdf5amMUoi3Wwio="
         },
         "axobject-query": {
             "version": "2.0.1",
@@ -969,6 +1036,22 @@
             "integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g==",
             "dev": true
         },
+        "bach": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/bach/-/bach-1.2.0.tgz",
+            "integrity": "sha1-Szzpa/JxNPeaG0FKUcFONMO9mIA=",
+            "requires": {
+                "arr-filter": "^1.1.1",
+                "arr-flatten": "^1.0.1",
+                "arr-map": "^2.0.0",
+                "array-each": "^1.0.0",
+                "array-initial": "^1.0.0",
+                "array-last": "^1.1.1",
+                "async-done": "^1.2.2",
+                "async-settle": "^1.0.0",
+                "now-and-later": "^2.0.0"
+            }
+        },
         "balanced-match": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -978,7 +1061,6 @@
             "version": "0.11.2",
             "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
             "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
-            "dev": true,
             "requires": {
                 "cache-base": "^1.0.1",
                 "class-utils": "^0.3.5",
@@ -993,7 +1075,6 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-                    "dev": true,
                     "requires": {
                         "is-descriptor": "^1.0.0"
                     }
@@ -1002,7 +1083,6 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-                    "dev": true,
                     "requires": {
                         "kind-of": "^6.0.0"
                     }
@@ -1011,7 +1091,6 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-                    "dev": true,
                     "requires": {
                         "kind-of": "^6.0.0"
                     }
@@ -1020,7 +1099,6 @@
                     "version": "1.0.2",
                     "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-                    "dev": true,
                     "requires": {
                         "is-accessor-descriptor": "^1.0.0",
                         "is-data-descriptor": "^1.0.0",
@@ -1030,14 +1108,12 @@
                 "isobject": {
                     "version": "3.0.1",
                     "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-                    "dev": true
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
                 },
                 "kind-of": {
                     "version": "6.0.2",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-                    "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-                    "dev": true
+                    "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
                 }
             }
         },
@@ -1046,11 +1122,6 @@
             "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
             "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
             "dev": true
-        },
-        "beeper": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
-            "integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak="
         },
         "big.js": {
             "version": "3.2.0",
@@ -1061,8 +1132,7 @@
         "binary-extensions": {
             "version": "1.11.0",
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
-            "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
-            "dev": true
+            "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU="
         },
         "bluebird": {
             "version": "3.5.1",
@@ -1086,13 +1156,30 @@
             }
         },
         "braces": {
-            "version": "1.8.5",
-            "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-            "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+            "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
             "requires": {
-                "expand-range": "^1.8.1",
-                "preserve": "^0.2.0",
-                "repeat-element": "^1.1.2"
+                "arr-flatten": "^1.1.0",
+                "array-unique": "^0.3.2",
+                "extend-shallow": "^2.0.1",
+                "fill-range": "^4.0.0",
+                "isobject": "^3.0.1",
+                "repeat-element": "^1.1.2",
+                "snapdragon": "^0.8.1",
+                "snapdragon-node": "^2.0.1",
+                "split-string": "^3.0.2",
+                "to-regex": "^3.0.1"
+            },
+            "dependencies": {
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "requires": {
+                        "is-extendable": "^0.1.0"
+                    }
+                }
             }
         },
         "brorand": {
@@ -1199,11 +1286,15 @@
                 }
             }
         },
+        "buffer-equal": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-1.0.0.tgz",
+            "integrity": "sha1-WWFrSYME1Var1GaWayLu2j7KX74="
+        },
         "buffer-from": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.0.tgz",
-            "integrity": "sha512-c5mRlguI/Pe2dSZmpER62rSCu0ryKmWddzRYsuXc50U2/g8jMOulc31VZMa4mYx31U5xsmSOpDCgH88Vl9cDGQ==",
-            "dev": true
+            "integrity": "sha512-c5mRlguI/Pe2dSZmpER62rSCu0ryKmWddzRYsuXc50U2/g8jMOulc31VZMa4mYx31U5xsmSOpDCgH88Vl9cDGQ=="
         },
         "buffer-xor": {
             "version": "1.0.3",
@@ -1214,8 +1305,7 @@
         "builtin-modules": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-            "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
-            "dev": true
+            "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
         },
         "builtin-status-codes": {
             "version": "3.0.0",
@@ -1298,7 +1388,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
             "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
-            "dev": true,
             "requires": {
                 "collection-visit": "^1.0.0",
                 "component-emitter": "^1.2.1",
@@ -1314,8 +1403,7 @@
                 "isobject": {
                     "version": "3.0.1",
                     "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-                    "dev": true
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
                 }
             }
         },
@@ -1334,10 +1422,16 @@
             "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
             "dev": true
         },
+        "camelcase": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+            "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+        },
         "chalk": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
             "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+            "dev": true,
             "requires": {
                 "ansi-styles": "^2.2.1",
                 "escape-string-regexp": "^1.0.2",
@@ -1356,7 +1450,6 @@
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.4.tgz",
             "integrity": "sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==",
-            "dev": true,
             "requires": {
                 "anymatch": "^2.0.0",
                 "async-each": "^1.0.0",
@@ -1376,14 +1469,12 @@
                 "array-unique": {
                     "version": "0.3.2",
                     "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-                    "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-                    "dev": true
+                    "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
                 },
                 "braces": {
                     "version": "2.3.2",
                     "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
                     "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-                    "dev": true,
                     "requires": {
                         "arr-flatten": "^1.1.0",
                         "array-unique": "^0.3.2",
@@ -1401,7 +1492,6 @@
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                    "dev": true,
                     "requires": {
                         "is-extendable": "^0.1.0"
                     }
@@ -1410,7 +1500,6 @@
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
                     "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-                    "dev": true,
                     "requires": {
                         "extend-shallow": "^2.0.1",
                         "is-number": "^3.0.0",
@@ -1422,7 +1511,6 @@
                     "version": "3.1.0",
                     "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
                     "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
-                    "dev": true,
                     "requires": {
                         "is-glob": "^3.1.0",
                         "path-dirname": "^1.0.0"
@@ -1432,7 +1520,6 @@
                             "version": "3.1.0",
                             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
                             "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-                            "dev": true,
                             "requires": {
                                 "is-extglob": "^2.1.0"
                             }
@@ -1442,14 +1529,12 @@
                 "is-extglob": {
                     "version": "2.1.1",
                     "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-                    "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-                    "dev": true
+                    "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
                 },
                 "is-glob": {
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
                     "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
-                    "dev": true,
                     "requires": {
                         "is-extglob": "^2.1.1"
                     }
@@ -1458,7 +1543,6 @@
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-                    "dev": true,
                     "requires": {
                         "kind-of": "^3.0.2"
                     }
@@ -1466,8 +1550,7 @@
                 "isobject": {
                     "version": "3.0.1",
                     "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-                    "dev": true
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
                 }
             }
         },
@@ -1506,7 +1589,6 @@
             "version": "0.3.6",
             "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
             "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
-            "dev": true,
             "requires": {
                 "arr-union": "^3.1.0",
                 "define-property": "^0.2.5",
@@ -1517,14 +1599,12 @@
                 "arr-union": {
                     "version": "3.1.0",
                     "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-                    "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
-                    "dev": true
+                    "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
                 },
                 "define-property": {
                     "version": "0.2.5",
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-                    "dev": true,
                     "requires": {
                         "is-descriptor": "^0.1.0"
                     }
@@ -1532,8 +1612,7 @@
                 "isobject": {
                     "version": "3.0.1",
                     "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-                    "dev": true
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
                 }
             }
         },
@@ -1543,15 +1622,79 @@
             "integrity": "sha1-sjTKIJsp72b8UY2bmNWEewDt8Ao=",
             "dev": true
         },
+        "cliui": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+            "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+            "requires": {
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wrap-ansi": "^2.0.0"
+            }
+        },
         "clone": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
-            "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk="
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+            "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
+        },
+        "clone-buffer": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
+            "integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg="
         },
         "clone-stats": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
-            "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE="
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+            "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA="
+        },
+        "cloneable-readable": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.2.tgz",
+            "integrity": "sha512-Bq6+4t+lbM8vhTs/Bef5c5AdEMtapp/iFb6+s4/Hh9MVTt8OLKH7ZOOZSCT+Ys7hsHvqv0GuMPJ1lnQJVHvxpg==",
+            "requires": {
+                "inherits": "^2.0.1",
+                "process-nextick-args": "^2.0.0",
+                "readable-stream": "^2.3.5"
+            },
+            "dependencies": {
+                "isarray": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+                },
+                "process-nextick-args": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+                    "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+                },
+                "readable-stream": {
+                    "version": "2.3.6",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+                    "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                    "requires": {
+                        "safe-buffer": "~5.1.0"
+                    }
+                }
+            }
+        },
+        "code-point-at": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+            "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
         },
         "coffee-script": {
             "version": "1.7.1",
@@ -1570,11 +1713,20 @@
                 }
             }
         },
+        "collection-map": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/collection-map/-/collection-map-1.0.0.tgz",
+            "integrity": "sha1-rqDwb40mx4DCt1SUOFVEsiVa8Yw=",
+            "requires": {
+                "arr-map": "^2.0.2",
+                "for-own": "^1.0.0",
+                "make-iterator": "^1.0.0"
+            }
+        },
         "collection-visit": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
             "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
-            "dev": true,
             "requires": {
                 "map-visit": "^1.0.0",
                 "object-visit": "^1.0.0"
@@ -1595,6 +1747,11 @@
             "integrity": "sha1-SxQVMEz1ACjqgWQ2Q72C6gWANok=",
             "dev": true
         },
+        "color-support": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+            "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="
+        },
         "commander": {
             "version": "2.16.0",
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.16.0.tgz",
@@ -1610,8 +1767,7 @@
         "component-emitter": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-            "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
-            "dev": true
+            "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
         },
         "concat-map": {
             "version": "0.0.1",
@@ -1622,7 +1778,6 @@
             "version": "1.6.2",
             "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
             "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-            "dev": true,
             "requires": {
                 "buffer-from": "^1.0.0",
                 "inherits": "^2.0.3",
@@ -1633,20 +1788,17 @@
                 "isarray": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-                    "dev": true
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
                 },
                 "process-nextick-args": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-                    "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
-                    "dev": true
+                    "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
                 },
                 "readable-stream": {
                     "version": "2.3.6",
                     "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-                    "dev": true,
                     "requires": {
                         "core-util-is": "~1.0.0",
                         "inherits": "~2.0.3",
@@ -1661,7 +1813,6 @@
                     "version": "1.1.1",
                     "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-                    "dev": true,
                     "requires": {
                         "safe-buffer": "~5.1.0"
                     }
@@ -1689,6 +1840,14 @@
             "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
             "dev": true
         },
+        "convert-source-map": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
+            "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
+            "requires": {
+                "safe-buffer": "~5.1.1"
+            }
+        },
         "copy-concurrently": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
@@ -1706,8 +1865,16 @@
         "copy-descriptor": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
-            "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
-            "dev": true
+            "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
+        },
+        "copy-props": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/copy-props/-/copy-props-2.0.4.tgz",
+            "integrity": "sha512-7cjuUME+p+S3HZlbllgsn2CDwS+5eCCX16qBgNC4jgSTf49qR1VKy/Zhl400m0IQXl/bPGEVqncgUUMjrr4s8A==",
+            "requires": {
+                "each-props": "^1.3.0",
+                "is-plain-object": "^2.0.1"
+            }
         },
         "core-util-is": {
             "version": "1.0.2",
@@ -1797,6 +1964,14 @@
             "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
             "dev": true
         },
+        "d": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+            "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+            "requires": {
+                "es5-ext": "^0.10.9"
+            }
+        },
         "damerau-levenshtein": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.4.tgz",
@@ -1809,11 +1984,6 @@
             "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
             "dev": true
         },
-        "dateformat": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.0.0.tgz",
-            "integrity": "sha1-J0Pjq7XD/CRi5SfcpEXgTp9N7hc="
-        },
         "debug": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
@@ -1823,11 +1993,15 @@
                 "ms": "2.0.0"
             }
         },
+        "decamelize": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+            "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+        },
         "decode-uri-component": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-            "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
-            "dev": true
+            "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
         },
         "deep-is": {
             "version": "0.1.3",
@@ -1835,19 +2009,30 @@
             "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
             "dev": true
         },
-        "defaults": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
-            "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+        "default-compare": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/default-compare/-/default-compare-1.0.0.tgz",
+            "integrity": "sha512-QWfXlM0EkAbqOCbD/6HjdwT19j7WCkMyiRhWilc4H9/5h/RzTF9gv5LYh1+CmDV5d1rki6KAWLtQale0xt20eQ==",
             "requires": {
-                "clone": "^1.0.2"
+                "kind-of": "^5.0.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+                    "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+                }
             }
+        },
+        "default-resolution": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/default-resolution/-/default-resolution-2.0.0.tgz",
+            "integrity": "sha1-vLgrqnKtebQmp2cy8aga1t8m1oQ="
         },
         "define-properties": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
             "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
-            "dev": true,
             "requires": {
                 "foreach": "^2.0.5",
                 "object-keys": "^1.0.8"
@@ -1857,7 +2042,6 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
             "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
-            "dev": true,
             "requires": {
                 "is-descriptor": "^1.0.2",
                 "isobject": "^3.0.1"
@@ -1867,7 +2051,6 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-                    "dev": true,
                     "requires": {
                         "kind-of": "^6.0.0"
                     }
@@ -1876,7 +2059,6 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-                    "dev": true,
                     "requires": {
                         "kind-of": "^6.0.0"
                     }
@@ -1885,7 +2067,6 @@
                     "version": "1.0.2",
                     "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-                    "dev": true,
                     "requires": {
                         "is-accessor-descriptor": "^1.0.0",
                         "is-data-descriptor": "^1.0.0",
@@ -1895,14 +2076,12 @@
                 "isobject": {
                     "version": "3.0.1",
                     "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-                    "dev": true
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
                 },
                 "kind-of": {
                     "version": "6.0.2",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-                    "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-                    "dev": true
+                    "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
                 }
             }
         },
@@ -1929,11 +2108,6 @@
                 }
             }
         },
-        "deprecated": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/deprecated/-/deprecated-0.0.1.tgz",
-            "integrity": "sha1-+cmvVGSvoeepcUWKi97yqpTVuxk="
-        },
         "des.js": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
@@ -1945,12 +2119,9 @@
             }
         },
         "detect-file": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-0.1.0.tgz",
-            "integrity": "sha1-STXe39lIhkjgBrASlWbpOGcR6mM=",
-            "requires": {
-                "fs-exists-sync": "^0.1.0"
-            }
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
+            "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc="
         },
         "diffie-hellman": {
             "version": "5.0.3",
@@ -1978,19 +2149,10 @@
             "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
             "dev": true
         },
-        "duplexer2": {
-            "version": "0.0.2",
-            "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
-            "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
-            "requires": {
-                "readable-stream": "~1.1.9"
-            }
-        },
         "duplexify": {
             "version": "3.6.0",
             "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.0.tgz",
             "integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
-            "dev": true,
             "requires": {
                 "end-of-stream": "^1.0.0",
                 "inherits": "^2.0.1",
@@ -2002,7 +2164,6 @@
                     "version": "1.4.1",
                     "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
                     "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
-                    "dev": true,
                     "requires": {
                         "once": "^1.4.0"
                     }
@@ -2010,14 +2171,12 @@
                 "isarray": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-                    "dev": true
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
                 },
                 "once": {
                     "version": "1.4.0",
                     "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
                     "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-                    "dev": true,
                     "requires": {
                         "wrappy": "1"
                     }
@@ -2025,14 +2184,12 @@
                 "process-nextick-args": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-                    "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
-                    "dev": true
+                    "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
                 },
                 "readable-stream": {
                     "version": "2.3.6",
                     "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-                    "dev": true,
                     "requires": {
                         "core-util-is": "~1.0.0",
                         "inherits": "~2.0.3",
@@ -2047,11 +2204,19 @@
                     "version": "1.1.1",
                     "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-                    "dev": true,
                     "requires": {
                         "safe-buffer": "~5.1.0"
                     }
                 }
+            }
+        },
+        "each-props": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/each-props/-/each-props-1.3.2.tgz",
+            "integrity": "sha512-vV0Hem3zAGkJAyU7JSjixeU66rwdynTAa1vofCrSA5fEln+m67Az9CcnkVD776/fsN/UjIWmBDoNRS6t6G9RfA==",
+            "requires": {
+                "is-plain-object": "^2.0.1",
+                "object.defaults": "^1.1.0"
             }
         },
         "elliptic": {
@@ -2082,11 +2247,21 @@
             "dev": true
         },
         "end-of-stream": {
-            "version": "0.1.5",
-            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
-            "integrity": "sha1-jhdyBsPICDfYVjLouTWd/osvbq8=",
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+            "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
             "requires": {
-                "once": "~1.3.0"
+                "once": "^1.4.0"
+            },
+            "dependencies": {
+                "once": {
+                    "version": "1.4.0",
+                    "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                    "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+                    "requires": {
+                        "wrappy": "1"
+                    }
+                }
             }
         },
         "enhanced-resolve": {
@@ -2121,7 +2296,6 @@
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
             "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-            "dev": true,
             "requires": {
                 "is-arrayish": "^0.2.1"
             }
@@ -2150,10 +2324,51 @@
                 "is-symbol": "^1.0.1"
             }
         },
+        "es5-ext": {
+            "version": "0.10.46",
+            "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.46.tgz",
+            "integrity": "sha512-24XxRvJXNFwEMpJb3nOkiRJKRoupmjYmOPVlI65Qy2SrtxwOTB+g6ODjBKOtwEHbYrhWRty9xxOWLNdClT2djw==",
+            "requires": {
+                "es6-iterator": "~2.0.3",
+                "es6-symbol": "~3.1.1",
+                "next-tick": "1"
+            }
+        },
+        "es6-iterator": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+            "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+            "requires": {
+                "d": "1",
+                "es5-ext": "^0.10.35",
+                "es6-symbol": "^3.1.1"
+            }
+        },
+        "es6-symbol": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+            "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+            "requires": {
+                "d": "1",
+                "es5-ext": "~0.10.14"
+            }
+        },
+        "es6-weak-map": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
+            "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
+            "requires": {
+                "d": "1",
+                "es5-ext": "^0.10.14",
+                "es6-iterator": "^2.0.1",
+                "es6-symbol": "^3.1.1"
+            }
+        },
         "escape-string-regexp": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+            "dev": true
         },
         "eslint": {
             "version": "5.2.0",
@@ -2813,33 +3028,57 @@
             }
         },
         "expand-brackets": {
-            "version": "0.1.5",
-            "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-            "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+            "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
             "requires": {
-                "is-posix-bracket": "^0.1.0"
-            }
-        },
-        "expand-range": {
-            "version": "1.8.2",
-            "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-            "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-            "requires": {
-                "fill-range": "^2.1.0"
+                "debug": "^2.3.3",
+                "define-property": "^0.2.5",
+                "extend-shallow": "^2.0.1",
+                "posix-character-classes": "^0.1.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "define-property": {
+                    "version": "0.2.5",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "requires": {
+                        "is-descriptor": "^0.1.0"
+                    }
+                },
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "requires": {
+                        "is-extendable": "^0.1.0"
+                    }
+                }
             }
         },
         "expand-tilde": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
-            "integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+            "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
             "requires": {
-                "os-homedir": "^1.0.1"
+                "homedir-polyfill": "^1.0.1"
             }
         },
         "extend": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-            "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
         },
         "extend-shallow": {
             "version": "1.1.4",
@@ -2868,19 +3107,76 @@
             }
         },
         "extglob": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-            "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+            "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
             "requires": {
-                "is-extglob": "^1.0.0"
+                "array-unique": "^0.3.2",
+                "define-property": "^1.0.0",
+                "expand-brackets": "^2.1.4",
+                "extend-shallow": "^2.0.1",
+                "fragment-cache": "^0.2.1",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+                    "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                    "requires": {
+                        "is-descriptor": "^1.0.0"
+                    }
+                },
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "requires": {
+                        "is-extendable": "^0.1.0"
+                    }
+                },
+                "is-accessor-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-data-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-descriptor": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+                    "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+                    "requires": {
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
+                    }
+                },
+                "kind-of": {
+                    "version": "6.0.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+                    "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+                }
             }
         },
         "fancy-log": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
-            "integrity": "sha1-Rb4X0Cu5kX1gzP/UmVyZnmyMmUg=",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.2.tgz",
+            "integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
             "requires": {
-                "chalk": "^1.1.1",
+                "ansi-gray": "^0.1.1",
+                "color-support": "^1.1.3",
                 "time-stamp": "^1.0.0"
             }
         },
@@ -2920,21 +3216,25 @@
                 }
             }
         },
-        "filename-regex": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-            "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
-        },
         "fill-range": {
-            "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
-            "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+            "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
             "requires": {
-                "is-number": "^2.1.0",
-                "isobject": "^2.0.0",
-                "randomatic": "^1.1.3",
-                "repeat-element": "^1.1.2",
-                "repeat-string": "^1.5.2"
+                "extend-shallow": "^2.0.1",
+                "is-number": "^3.0.0",
+                "repeat-string": "^1.6.1",
+                "to-regex-range": "^2.1.0"
+            },
+            "dependencies": {
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "requires": {
+                        "is-extendable": "^0.1.0"
+                    }
+                }
             }
         },
         "find-cache-dir": {
@@ -2968,11 +3268,6 @@
                 }
             }
         },
-        "find-index": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz",
-            "integrity": "sha1-Z101iyyjiS15Whq0cjL4tuLg3eQ="
-        },
         "find-root": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
@@ -2983,21 +3278,20 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
             "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-            "dev": true,
             "requires": {
                 "path-exists": "^2.0.0",
                 "pinkie-promise": "^2.0.0"
             }
         },
         "findup-sync": {
-            "version": "0.4.3",
-            "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.4.3.tgz",
-            "integrity": "sha1-QAQ5Kee8YK3wt/SCfExudaDeyhI=",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
+            "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
             "requires": {
-                "detect-file": "^0.1.0",
-                "is-glob": "^2.0.1",
-                "micromatch": "^2.3.7",
-                "resolve-dir": "^0.1.0"
+                "detect-file": "^1.0.0",
+                "is-glob": "^3.1.0",
+                "micromatch": "^3.0.4",
+                "resolve-dir": "^1.0.1"
             }
         },
         "fined": {
@@ -3010,27 +3304,12 @@
                 "object.defaults": "^1.1.0",
                 "object.pick": "^1.2.0",
                 "parse-filepath": "^1.0.1"
-            },
-            "dependencies": {
-                "expand-tilde": {
-                    "version": "2.0.2",
-                    "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
-                    "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
-                    "requires": {
-                        "homedir-polyfill": "^1.0.1"
-                    }
-                }
             }
         },
-        "first-chunk-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
-            "integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04="
-        },
         "flagged-respawn": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-0.3.2.tgz",
-            "integrity": "sha1-/xke3c1wiKZ1smEP/8l2vpuAdLU="
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-1.0.0.tgz",
+            "integrity": "sha1-Tnmumy6zi/hrO7Vr8+ClaqX8q9c="
         },
         "flat-cache": {
             "version": "1.2.2",
@@ -3056,7 +3335,6 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.3.tgz",
             "integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
-            "dev": true,
             "requires": {
                 "inherits": "^2.0.1",
                 "readable-stream": "^2.0.4"
@@ -3065,20 +3343,17 @@
                 "isarray": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-                    "dev": true
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
                 },
                 "process-nextick-args": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-                    "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
-                    "dev": true
+                    "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
                 },
                 "readable-stream": {
                     "version": "2.3.6",
                     "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-                    "dev": true,
                     "requires": {
                         "core-util-is": "~1.0.0",
                         "inherits": "~2.0.3",
@@ -3093,7 +3368,6 @@
                     "version": "1.1.1",
                     "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-                    "dev": true,
                     "requires": {
                         "safe-buffer": "~5.1.0"
                     }
@@ -3106,9 +3380,9 @@
             "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
         },
         "for-own": {
-            "version": "0.1.5",
-            "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-            "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
+            "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
             "requires": {
                 "for-in": "^1.0.1"
             }
@@ -3116,14 +3390,12 @@
         "foreach": {
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-            "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
-            "dev": true
+            "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
         },
         "fragment-cache": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
             "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
-            "dev": true,
             "requires": {
                 "map-cache": "^0.2.2"
             }
@@ -3176,10 +3448,14 @@
                 }
             }
         },
-        "fs-exists-sync": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
-            "integrity": "sha1-mC1ok6+RjnLQjeyehnP/K1qNat0="
+        "fs-mkdirp-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs-mkdirp-stream/-/fs-mkdirp-stream-1.0.0.tgz",
+            "integrity": "sha1-C3gV/DIBxqaeFNuYzgmMFpNSWes=",
+            "requires": {
+                "graceful-fs": "^4.1.11",
+                "through2": "^2.0.3"
+            }
         },
         "fs-write-stream-atomic": {
             "version": "1.0.10",
@@ -3204,14 +3480,12 @@
         "fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-            "dev": true
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
         },
         "fsevents": {
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
             "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
-            "dev": true,
             "optional": true,
             "requires": {
                 "nan": "^2.9.2",
@@ -3221,24 +3495,20 @@
                 "abbrev": {
                     "version": "1.1.1",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "ansi-regex": {
                     "version": "2.1.1",
-                    "bundled": true,
-                    "dev": true
+                    "bundled": true
                 },
                 "aproba": {
                     "version": "1.2.0",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "are-we-there-yet": {
                     "version": "1.1.4",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "delegates": "^1.0.0",
@@ -3247,13 +3517,11 @@
                 },
                 "balanced-match": {
                     "version": "1.0.0",
-                    "bundled": true,
-                    "dev": true
+                    "bundled": true
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "bundled": true,
-                    "dev": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
@@ -3262,34 +3530,28 @@
                 "chownr": {
                     "version": "1.0.1",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "code-point-at": {
                     "version": "1.1.0",
-                    "bundled": true,
-                    "dev": true
+                    "bundled": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
-                    "bundled": true,
-                    "dev": true
+                    "bundled": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
-                    "bundled": true,
-                    "dev": true
+                    "bundled": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "debug": {
                     "version": "2.6.9",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "ms": "2.0.0"
@@ -3298,25 +3560,21 @@
                 "deep-extend": {
                     "version": "0.5.1",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "delegates": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "detect-libc": {
                     "version": "1.0.3",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "fs-minipass": {
                     "version": "1.2.5",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "minipass": "^2.2.1"
@@ -3325,13 +3583,11 @@
                 "fs.realpath": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "gauge": {
                     "version": "2.7.4",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "aproba": "^1.0.3",
@@ -3347,7 +3603,6 @@
                 "glob": {
                     "version": "7.1.2",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "fs.realpath": "^1.0.0",
@@ -3361,13 +3616,11 @@
                 "has-unicode": {
                     "version": "2.0.1",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "iconv-lite": {
                     "version": "0.4.21",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "safer-buffer": "^2.1.0"
@@ -3376,7 +3629,6 @@
                 "ignore-walk": {
                     "version": "3.0.1",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "minimatch": "^3.0.4"
@@ -3385,7 +3637,6 @@
                 "inflight": {
                     "version": "1.0.6",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "once": "^1.3.0",
@@ -3394,19 +3645,16 @@
                 },
                 "inherits": {
                     "version": "2.0.3",
-                    "bundled": true,
-                    "dev": true
+                    "bundled": true
                 },
                 "ini": {
                     "version": "1.3.5",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "is-fullwidth-code-point": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
                     }
@@ -3414,26 +3662,22 @@
                 "isarray": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "minimatch": {
                     "version": "3.0.4",
                     "bundled": true,
-                    "dev": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
                     }
                 },
                 "minimist": {
                     "version": "0.0.8",
-                    "bundled": true,
-                    "dev": true
+                    "bundled": true
                 },
                 "minipass": {
                     "version": "2.2.4",
                     "bundled": true,
-                    "dev": true,
                     "requires": {
                         "safe-buffer": "^5.1.1",
                         "yallist": "^3.0.0"
@@ -3442,7 +3686,6 @@
                 "minizlib": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "minipass": "^2.2.1"
@@ -3451,7 +3694,6 @@
                 "mkdirp": {
                     "version": "0.5.1",
                     "bundled": true,
-                    "dev": true,
                     "requires": {
                         "minimist": "0.0.8"
                     }
@@ -3459,13 +3701,11 @@
                 "ms": {
                     "version": "2.0.0",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "needle": {
                     "version": "2.2.0",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "debug": "^2.1.2",
@@ -3476,7 +3716,6 @@
                 "node-pre-gyp": {
                     "version": "0.10.0",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "detect-libc": "^1.0.2",
@@ -3494,7 +3733,6 @@
                 "nopt": {
                     "version": "4.0.1",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "abbrev": "1",
@@ -3504,13 +3742,11 @@
                 "npm-bundled": {
                     "version": "1.0.3",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "npm-packlist": {
                     "version": "1.1.10",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "ignore-walk": "^3.0.1",
@@ -3520,7 +3756,6 @@
                 "npmlog": {
                     "version": "4.1.2",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "are-we-there-yet": "~1.1.2",
@@ -3531,19 +3766,16 @@
                 },
                 "number-is-nan": {
                     "version": "1.0.1",
-                    "bundled": true,
-                    "dev": true
+                    "bundled": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "once": {
                     "version": "1.4.0",
                     "bundled": true,
-                    "dev": true,
                     "requires": {
                         "wrappy": "1"
                     }
@@ -3551,19 +3783,16 @@
                 "os-homedir": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "os-tmpdir": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "osenv": {
                     "version": "0.1.5",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "os-homedir": "^1.0.0",
@@ -3573,19 +3802,16 @@
                 "path-is-absolute": {
                     "version": "1.0.1",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "process-nextick-args": {
                     "version": "2.0.0",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "rc": {
                     "version": "1.2.7",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "deep-extend": "^0.5.1",
@@ -3597,7 +3823,6 @@
                         "minimist": {
                             "version": "1.2.0",
                             "bundled": true,
-                            "dev": true,
                             "optional": true
                         }
                     }
@@ -3605,7 +3830,6 @@
                 "readable-stream": {
                     "version": "2.3.6",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "core-util-is": "~1.0.0",
@@ -3620,7 +3844,6 @@
                 "rimraf": {
                     "version": "2.6.2",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "glob": "^7.0.5"
@@ -3628,43 +3851,36 @@
                 },
                 "safe-buffer": {
                     "version": "5.1.1",
-                    "bundled": true,
-                    "dev": true
+                    "bundled": true
                 },
                 "safer-buffer": {
                     "version": "2.1.2",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "sax": {
                     "version": "1.2.4",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "semver": {
                     "version": "5.5.0",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "set-blocking": {
                     "version": "2.0.0",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "signal-exit": {
                     "version": "3.0.2",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "string-width": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "dev": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",
@@ -3674,7 +3890,6 @@
                 "string_decoder": {
                     "version": "1.1.1",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "safe-buffer": "~5.1.0"
@@ -3683,7 +3898,6 @@
                 "strip-ansi": {
                     "version": "3.0.1",
                     "bundled": true,
-                    "dev": true,
                     "requires": {
                         "ansi-regex": "^2.0.0"
                     }
@@ -3691,13 +3905,11 @@
                 "strip-json-comments": {
                     "version": "2.0.1",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "tar": {
                     "version": "4.4.1",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "chownr": "^1.0.1",
@@ -3712,13 +3924,11 @@
                 "util-deprecate": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "dev": true,
                     "optional": true
                 },
                 "wide-align": {
                     "version": "1.1.2",
                     "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "string-width": "^1.0.2"
@@ -3726,21 +3936,18 @@
                 },
                 "wrappy": {
                     "version": "1.0.2",
-                    "bundled": true,
-                    "dev": true
+                    "bundled": true
                 },
                 "yallist": {
                     "version": "3.0.2",
-                    "bundled": true,
-                    "dev": true
+                    "bundled": true
                 }
             }
         },
         "function-bind": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-            "dev": true
+            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
         },
         "functional-red-black-tree": {
             "version": "1.0.1",
@@ -3748,13 +3955,10 @@
             "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
             "dev": true
         },
-        "gaze": {
-            "version": "0.5.2",
-            "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
-            "integrity": "sha1-QLcJU30k0dRXZ9takIaJ3+aaxE8=",
-            "requires": {
-                "globule": "~0.1.0"
-            }
+        "get-caller-file": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+            "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
         },
         "get-stdin": {
             "version": "5.0.1",
@@ -3765,106 +3969,112 @@
         "get-value": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
-            "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
-            "dev": true
+            "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
         },
         "glob": {
-            "version": "4.5.3",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
-            "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
+            "version": "7.1.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+            "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
             "requires": {
+                "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
                 "inherits": "2",
-                "minimatch": "^2.0.1",
-                "once": "^1.3.0"
-            }
-        },
-        "glob-base": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-            "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-            "requires": {
-                "glob-parent": "^2.0.0",
-                "is-glob": "^2.0.0"
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
             }
         },
         "glob-parent": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-            "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+            "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
             "requires": {
-                "is-glob": "^2.0.0"
+                "is-glob": "^3.1.0",
+                "path-dirname": "^1.0.0"
             }
         },
         "glob-stream": {
-            "version": "3.1.18",
-            "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz",
-            "integrity": "sha1-kXCl8St5Awb9/lmPMT+PeVT9FDs=",
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-6.1.0.tgz",
+            "integrity": "sha1-cEXJlBOz65SIjYOrRtC0BMx73eQ=",
             "requires": {
-                "glob": "^4.3.1",
-                "glob2base": "^0.0.12",
-                "minimatch": "^2.0.1",
-                "ordered-read-streams": "^0.1.0",
-                "through2": "^0.6.1",
-                "unique-stream": "^1.0.0"
+                "extend": "^3.0.0",
+                "glob": "^7.1.1",
+                "glob-parent": "^3.1.0",
+                "is-negated-glob": "^1.0.0",
+                "ordered-read-streams": "^1.0.0",
+                "pumpify": "^1.3.5",
+                "readable-stream": "^2.1.5",
+                "remove-trailing-separator": "^1.0.1",
+                "to-absolute-glob": "^2.0.0",
+                "unique-stream": "^2.0.2"
             },
             "dependencies": {
+                "isarray": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+                },
+                "process-nextick-args": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+                    "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+                },
                 "readable-stream": {
-                    "version": "1.0.34",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-                    "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+                    "version": "2.3.6",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+                    "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "requires": {
                         "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.1",
-                        "isarray": "0.0.1",
-                        "string_decoder": "~0.10.x"
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
                     }
                 },
-                "through2": {
-                    "version": "0.6.5",
-                    "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-                    "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+                "string_decoder": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "requires": {
-                        "readable-stream": ">=1.0.33-1 <1.1.0-0",
-                        "xtend": ">=4.0.0 <4.1.0-0"
+                        "safe-buffer": "~5.1.0"
                     }
                 }
             }
         },
         "glob-watcher": {
-            "version": "0.0.6",
-            "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.6.tgz",
-            "integrity": "sha1-uVtKjfdLOcgymLDAXJeLTZo7cQs=",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-5.0.1.tgz",
+            "integrity": "sha512-fK92r2COMC199WCyGUblrZKhjra3cyVMDiypDdqg1vsSDmexnbYivK1kNR4QItiNXLKmGlqan469ks67RtNa2g==",
             "requires": {
-                "gaze": "^0.5.1"
-            }
-        },
-        "glob2base": {
-            "version": "0.0.12",
-            "resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
-            "integrity": "sha1-nUGbPijxLoOjYhZKJ3BVkiycDVY=",
-            "requires": {
-                "find-index": "^0.1.1"
+                "async-done": "^1.2.0",
+                "chokidar": "^2.0.0",
+                "just-debounce": "^1.0.0",
+                "object.defaults": "^1.1.0"
             }
         },
         "global-modules": {
-            "version": "0.2.3",
-            "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
-            "integrity": "sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
+            "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
             "requires": {
-                "global-prefix": "^0.1.4",
-                "is-windows": "^0.2.0"
+                "global-prefix": "^1.0.1",
+                "is-windows": "^1.0.1",
+                "resolve-dir": "^1.0.0"
             }
         },
         "global-prefix": {
-            "version": "0.1.5",
-            "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
-            "integrity": "sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
+            "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
             "requires": {
-                "homedir-polyfill": "^1.0.0",
+                "expand-tilde": "^2.0.2",
+                "homedir-polyfill": "^1.0.1",
                 "ini": "^1.3.4",
-                "is-windows": "^0.2.0",
-                "which": "^1.2.12"
+                "is-windows": "^1.0.1",
+                "which": "^1.2.14"
             }
         },
         "globals": {
@@ -3918,62 +4128,18 @@
                 }
             }
         },
-        "globule": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
-            "integrity": "sha1-2cjt3h2nnRJaFRt5UzuXhnY0auU=",
-            "requires": {
-                "glob": "~3.1.21",
-                "lodash": "~1.0.1",
-                "minimatch": "~0.2.11"
-            },
-            "dependencies": {
-                "glob": {
-                    "version": "3.1.21",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
-                    "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
-                    "requires": {
-                        "graceful-fs": "~1.2.0",
-                        "inherits": "1",
-                        "minimatch": "~0.2.11"
-                    }
-                },
-                "graceful-fs": {
-                    "version": "1.2.3",
-                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
-                    "integrity": "sha1-FaSAaldUfLLS2/J/QuiajDRRs2Q="
-                },
-                "inherits": {
-                    "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
-                    "integrity": "sha1-ykMJ2t7mtUzAuNJH6NfHoJdb3Js="
-                },
-                "minimatch": {
-                    "version": "0.2.14",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-                    "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
-                    "requires": {
-                        "lru-cache": "2",
-                        "sigmund": "~1.0.0"
-                    }
-                }
-            }
-        },
         "glogg": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz",
-            "integrity": "sha1-f+DxmfV6yQbPUS/urY+Q7kooT8U=",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.1.tgz",
+            "integrity": "sha512-ynYqXLoluBKf9XGR1gA59yEJisIL7YHEH4xr3ZziHB5/yl4qWfaK8Js9jGe6gBGCSCKVqiyO30WnRZADvemUNw==",
             "requires": {
                 "sparkles": "^1.0.0"
             }
         },
         "graceful-fs": {
-            "version": "3.0.11",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
-            "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
-            "requires": {
-                "natives": "^1.1.0"
-            }
+            "version": "4.1.11",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+            "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
         },
         "growl": {
             "version": "1.10.5",
@@ -3988,48 +4154,46 @@
             "dev": true
         },
         "gulp": {
-            "version": "3.9.1",
-            "resolved": "https://registry.npmjs.org/gulp/-/gulp-3.9.1.tgz",
-            "integrity": "sha1-VxzkWSjdQK9lFPxAEYZgFsE4RbQ=",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/gulp/-/gulp-4.0.0.tgz",
+            "integrity": "sha1-lXZsYB2t5Kd+0+eyttwDiBtZY2Y=",
             "requires": {
-                "archy": "^1.0.0",
-                "chalk": "^1.0.0",
-                "deprecated": "^0.0.1",
-                "gulp-util": "^3.0.0",
-                "interpret": "^1.0.0",
-                "liftoff": "^2.1.0",
-                "minimist": "^1.1.0",
-                "orchestrator": "^0.3.0",
-                "pretty-hrtime": "^1.0.0",
-                "semver": "^4.1.0",
-                "tildify": "^1.0.0",
-                "v8flags": "^2.0.2",
-                "vinyl-fs": "^0.3.0"
-            }
-        },
-        "gulp-util": {
-            "version": "3.0.8",
-            "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
-            "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
-            "requires": {
-                "array-differ": "^1.0.0",
-                "array-uniq": "^1.0.2",
-                "beeper": "^1.0.0",
-                "chalk": "^1.0.0",
-                "dateformat": "^2.0.0",
-                "fancy-log": "^1.1.0",
-                "gulplog": "^1.0.0",
-                "has-gulplog": "^0.1.0",
-                "lodash._reescape": "^3.0.0",
-                "lodash._reevaluate": "^3.0.0",
-                "lodash._reinterpolate": "^3.0.0",
-                "lodash.template": "^3.0.0",
-                "minimist": "^1.1.0",
-                "multipipe": "^0.1.2",
-                "object-assign": "^3.0.0",
-                "replace-ext": "0.0.1",
-                "through2": "^2.0.0",
-                "vinyl": "^0.5.0"
+                "glob-watcher": "^5.0.0",
+                "gulp-cli": "^2.0.0",
+                "undertaker": "^1.0.0",
+                "vinyl-fs": "^3.0.0"
+            },
+            "dependencies": {
+                "gulp-cli": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/gulp-cli/-/gulp-cli-2.0.1.tgz",
+                    "integrity": "sha512-RxujJJdN8/O6IW2nPugl7YazhmrIEjmiVfPKrWt68r71UCaLKS71Hp0gpKT+F6qOUFtr7KqtifDKaAJPRVvMYQ==",
+                    "requires": {
+                        "ansi-colors": "^1.0.1",
+                        "archy": "^1.0.0",
+                        "array-sort": "^1.0.0",
+                        "color-support": "^1.1.3",
+                        "concat-stream": "^1.6.0",
+                        "copy-props": "^2.0.1",
+                        "fancy-log": "^1.3.2",
+                        "gulplog": "^1.0.0",
+                        "interpret": "^1.1.0",
+                        "isobject": "^3.0.1",
+                        "liftoff": "^2.5.0",
+                        "matchdep": "^2.0.0",
+                        "mute-stdout": "^1.0.0",
+                        "pretty-hrtime": "^1.0.0",
+                        "replace-homedir": "^1.0.0",
+                        "semver-greatest-satisfied-range": "^1.1.0",
+                        "v8flags": "^3.0.1",
+                        "yargs": "^7.1.0"
+                    }
+                },
+                "interpret": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
+                    "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ="
+                }
             }
         },
         "gulplog": {
@@ -4053,6 +4217,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
             "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+            "dev": true,
             "requires": {
                 "ansi-regex": "^2.0.0"
             }
@@ -4063,25 +4228,15 @@
             "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
             "dev": true
         },
-        "has-gulplog": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
-            "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
-            "requires": {
-                "sparkles": "^1.0.0"
-            }
-        },
         "has-symbols": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
-            "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
-            "dev": true
+            "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q="
         },
         "has-value": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
             "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
-            "dev": true,
             "requires": {
                 "get-value": "^2.0.6",
                 "has-values": "^1.0.0",
@@ -4091,8 +4246,7 @@
                 "isobject": {
                     "version": "3.0.1",
                     "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-                    "dev": true
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
                 }
             }
         },
@@ -4100,7 +4254,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
             "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
-            "dev": true,
             "requires": {
                 "is-number": "^3.0.0",
                 "kind-of": "^4.0.0"
@@ -4110,7 +4263,6 @@
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-                    "dev": true,
                     "requires": {
                         "kind-of": "^3.0.2"
                     },
@@ -4119,7 +4271,6 @@
                             "version": "3.2.2",
                             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                            "dev": true,
                             "requires": {
                                 "is-buffer": "^1.1.5"
                             }
@@ -4130,7 +4281,6 @@
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
                     "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-                    "dev": true,
                     "requires": {
                         "is-buffer": "^1.1.5"
                     }
@@ -4179,8 +4329,7 @@
         "hosted-git-info": {
             "version": "2.7.1",
             "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
-            "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
-            "dev": true
+            "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w=="
         },
         "https-browserify": {
             "version": "1.0.0",
@@ -4236,14 +4385,15 @@
             "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         },
         "ini": {
-            "version": "1.3.4",
-            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-            "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4="
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+            "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
         },
         "interpret": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
-            "integrity": "sha1-y8NcYu7uc/Gat7EKgBURQBr8D5A="
+            "integrity": "sha1-y8NcYu7uc/Gat7EKgBURQBr8D5A=",
+            "dev": true
         },
         "invariant": {
             "version": "2.2.4",
@@ -4254,20 +4404,24 @@
                 "loose-envify": "^1.0.0"
             }
         },
+        "invert-kv": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+            "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+        },
         "is-absolute": {
-            "version": "0.2.6",
-            "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.2.6.tgz",
-            "integrity": "sha1-IN5p89uULvLYe5wto28XIjWxtes=",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
+            "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
             "requires": {
-                "is-relative": "^0.2.1",
-                "is-windows": "^0.2.0"
+                "is-relative": "^1.0.0",
+                "is-windows": "^1.0.1"
             }
         },
         "is-accessor-descriptor": {
             "version": "0.1.6",
             "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
             "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-            "dev": true,
             "requires": {
                 "kind-of": "^3.0.2"
             }
@@ -4275,14 +4429,12 @@
         "is-arrayish": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-            "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-            "dev": true
+            "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
         },
         "is-binary-path": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
             "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
-            "dev": true,
             "requires": {
                 "binary-extensions": "^1.0.0"
             }
@@ -4296,7 +4448,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
             "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-            "dev": true,
             "requires": {
                 "builtin-modules": "^1.0.0"
             }
@@ -4311,7 +4462,6 @@
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
             "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-            "dev": true,
             "requires": {
                 "kind-of": "^3.0.2"
             }
@@ -4326,7 +4476,6 @@
             "version": "0.1.6",
             "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
             "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-            "dev": true,
             "requires": {
                 "is-accessor-descriptor": "^0.1.6",
                 "is-data-descriptor": "^0.1.4",
@@ -4336,22 +4485,8 @@
                 "kind-of": {
                     "version": "5.1.0",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-                    "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-                    "dev": true
+                    "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
                 }
-            }
-        },
-        "is-dotfile": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-            "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
-        },
-        "is-equal-shallow": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-            "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-            "requires": {
-                "is-primitive": "^2.0.0"
             }
         },
         "is-extendable": {
@@ -4360,22 +4495,35 @@
             "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
         },
         "is-extglob": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-            "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+            "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
         },
-        "is-glob": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-            "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+        "is-fullwidth-code-point": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+            "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
             "requires": {
-                "is-extglob": "^1.0.0"
+                "number-is-nan": "^1.0.0"
             }
         },
+        "is-glob": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+            "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+            "requires": {
+                "is-extglob": "^2.1.0"
+            }
+        },
+        "is-negated-glob": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-negated-glob/-/is-negated-glob-1.0.0.tgz",
+            "integrity": "sha1-aRC8pdqMleeEtXUbl2z1oQ/uNtI="
+        },
         "is-number": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-            "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+            "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
             "requires": {
                 "kind-of": "^3.0.2"
             }
@@ -4419,16 +4567,6 @@
                 }
             }
         },
-        "is-posix-bracket": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-            "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
-        },
-        "is-primitive": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-            "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
-        },
         "is-promise": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
@@ -4445,11 +4583,11 @@
             }
         },
         "is-relative": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.2.1.tgz",
-            "integrity": "sha1-0n9MfVFtF1+2ENuEu+7yPDvJeqU=",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
+            "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
             "requires": {
-                "is-unc-path": "^0.1.1"
+                "is-unc-path": "^1.0.0"
             }
         },
         "is-symbol": {
@@ -4459,11 +4597,11 @@
             "dev": true
         },
         "is-unc-path": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-0.1.2.tgz",
-            "integrity": "sha1-arBTpyVzwQJQ/0FqOBTDUXivObk=",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
+            "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
             "requires": {
-                "unc-path-regex": "^0.1.0"
+                "unc-path-regex": "^0.1.2"
             }
         },
         "is-utf8": {
@@ -4471,15 +4609,21 @@
             "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
             "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
         },
+        "is-valid-glob": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-1.0.0.tgz",
+            "integrity": "sha1-Kb8+/3Ab4tTTFdusw5vDn+j2Aao="
+        },
         "is-windows": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
-            "integrity": "sha1-3hqm1j6indJIc3tp8f+LgALSEIw="
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+            "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
         },
         "isarray": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-            "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+            "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+            "dev": true
         },
         "isexe": {
             "version": "2.0.0",
@@ -4487,19 +4631,9 @@
             "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
         },
         "isobject": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-            "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-            "requires": {
-                "isarray": "1.0.0"
-            },
-            "dependencies": {
-                "isarray": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-                }
-            }
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+            "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
         },
         "jasmine-growl-reporter": {
             "version": "1.0.1",
@@ -4631,6 +4765,14 @@
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
             "dev": true
         },
+        "json-stable-stringify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+            "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+            "requires": {
+                "jsonify": "~0.0.0"
+            }
+        },
         "json-stable-stringify-without-jsonify": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -4643,6 +4785,11 @@
             "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
             "dev": true
         },
+        "jsonify": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+            "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+        },
         "jsx-ast-utils": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz",
@@ -4652,12 +4799,84 @@
                 "array-includes": "^3.0.3"
             }
         },
+        "just-debounce": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/just-debounce/-/just-debounce-1.0.0.tgz",
+            "integrity": "sha1-h/zPrv/AtozRnVX2cilD+SnqNeo="
+        },
         "kind-of": {
             "version": "3.2.2",
             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
             "requires": {
                 "is-buffer": "^1.1.5"
+            }
+        },
+        "last-run": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/last-run/-/last-run-1.1.1.tgz",
+            "integrity": "sha1-RblpQsF7HHnHchmCWbqUO+v4yls=",
+            "requires": {
+                "default-resolution": "^2.0.0",
+                "es6-weak-map": "^2.0.1"
+            }
+        },
+        "lazystream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
+            "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
+            "requires": {
+                "readable-stream": "^2.0.5"
+            },
+            "dependencies": {
+                "isarray": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+                },
+                "process-nextick-args": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+                    "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+                },
+                "readable-stream": {
+                    "version": "2.3.6",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+                    "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                    "requires": {
+                        "safe-buffer": "~5.1.0"
+                    }
+                }
+            }
+        },
+        "lcid": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+            "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+            "requires": {
+                "invert-kv": "^1.0.0"
+            }
+        },
+        "lead": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/lead/-/lead-1.0.0.tgz",
+            "integrity": "sha1-bxT5mje+Op3XhPVJVpDlkDRm7kI=",
+            "requires": {
+                "flush-write-stream": "^1.0.2"
             }
         },
         "levn": {
@@ -4671,17 +4890,16 @@
             }
         },
         "liftoff": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.3.0.tgz",
-            "integrity": "sha1-qY8v9nGD2Lp8+soQVIvX/wVQs4U=",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.5.0.tgz",
+            "integrity": "sha1-IAkpG7Mc6oYbvxCnwVooyvdcMew=",
             "requires": {
                 "extend": "^3.0.0",
-                "findup-sync": "^0.4.2",
+                "findup-sync": "^2.0.0",
                 "fined": "^1.0.1",
-                "flagged-respawn": "^0.3.2",
-                "lodash.isplainobject": "^4.0.4",
-                "lodash.isstring": "^4.0.1",
-                "lodash.mapvalues": "^4.4.0",
+                "flagged-respawn": "^1.0.0",
+                "is-plain-object": "^2.0.4",
+                "object.map": "^1.0.0",
                 "rechoir": "^0.6.2",
                 "resolve": "^1.1.7"
             }
@@ -4747,134 +4965,10 @@
                 }
             }
         },
-        "lodash": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
-            "integrity": "sha1-j1dWDIO1n8JwvT1WG2kAQ0MOJVE="
-        },
-        "lodash._basecopy": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-            "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY="
-        },
-        "lodash._basetostring": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
-            "integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U="
-        },
-        "lodash._basevalues": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
-            "integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc="
-        },
-        "lodash._getnative": {
-            "version": "3.9.1",
-            "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-            "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
-        },
-        "lodash._isiterateecall": {
-            "version": "3.0.9",
-            "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-            "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw="
-        },
-        "lodash._reescape": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
-            "integrity": "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo="
-        },
-        "lodash._reevaluate": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
-            "integrity": "sha1-WLx0xAZklTrgsSTYBpltrKQx4u0="
-        },
-        "lodash._reinterpolate": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-            "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
-        },
-        "lodash._root": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
-            "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI="
-        },
         "lodash.debounce": {
             "version": "4.0.8",
             "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-            "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
-            "dev": true
-        },
-        "lodash.escape": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
-            "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
-            "requires": {
-                "lodash._root": "^3.0.0"
-            }
-        },
-        "lodash.isarguments": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-            "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
-        },
-        "lodash.isarray": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-            "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
-        },
-        "lodash.isplainobject": {
-            "version": "4.0.6",
-            "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-            "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
-        },
-        "lodash.isstring": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-            "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
-        },
-        "lodash.keys": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-            "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-            "requires": {
-                "lodash._getnative": "^3.0.0",
-                "lodash.isarguments": "^3.0.0",
-                "lodash.isarray": "^3.0.0"
-            }
-        },
-        "lodash.mapvalues": {
-            "version": "4.6.0",
-            "resolved": "https://registry.npmjs.org/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz",
-            "integrity": "sha1-G6+lAF3p3W9PJmaMMMo3IwzJaJw="
-        },
-        "lodash.restparam": {
-            "version": "3.6.1",
-            "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
-            "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU="
-        },
-        "lodash.template": {
-            "version": "3.6.2",
-            "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
-            "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
-            "requires": {
-                "lodash._basecopy": "^3.0.0",
-                "lodash._basetostring": "^3.0.0",
-                "lodash._basevalues": "^3.0.0",
-                "lodash._isiterateecall": "^3.0.0",
-                "lodash._reinterpolate": "^3.0.0",
-                "lodash.escape": "^3.0.0",
-                "lodash.keys": "^3.0.0",
-                "lodash.restparam": "^3.0.0",
-                "lodash.templatesettings": "^3.0.0"
-            }
-        },
-        "lodash.templatesettings": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
-            "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
-            "requires": {
-                "lodash._reinterpolate": "^3.0.0",
-                "lodash.escape": "^3.0.0"
-            }
+            "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
         },
         "long": {
             "version": "3.2.0",
@@ -4890,11 +4984,6 @@
             "requires": {
                 "js-tokens": "^3.0.0 || ^4.0.0"
             }
-        },
-        "lru-cache": {
-            "version": "2.7.3",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-            "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
         },
         "make-dir": {
             "version": "1.3.0",
@@ -4913,6 +5002,21 @@
                 }
             }
         },
+        "make-iterator": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/make-iterator/-/make-iterator-1.0.1.tgz",
+            "integrity": "sha512-pxiuXh0iVEq7VM7KMIhs5gxsfxCux2URptUQaXo4iZZJxBAzTPOLE2BumO5dbfVYq/hBJFBR/a1mFDmOx5AGmw==",
+            "requires": {
+                "kind-of": "^6.0.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "6.0.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+                    "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+                }
+            }
+        },
         "mamacro": {
             "version": "0.0.3",
             "resolved": "https://registry.npmjs.org/mamacro/-/mamacro-0.0.3.tgz",
@@ -4928,9 +5032,19 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
             "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
-            "dev": true,
             "requires": {
                 "object-visit": "^1.0.0"
+            }
+        },
+        "matchdep": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/matchdep/-/matchdep-2.0.0.tgz",
+            "integrity": "sha1-xvNINKDY28OzfCfui7yyfHd1WC4=",
+            "requires": {
+                "findup-sync": "^2.0.0",
+                "micromatch": "^3.0.4",
+                "resolve": "^1.4.0",
+                "stack-trace": "0.0.10"
             }
         },
         "md5.js": {
@@ -4950,23 +5064,47 @@
             "dev": true
         },
         "micromatch": {
-            "version": "2.3.11",
-            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-            "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+            "version": "3.1.10",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+            "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
             "requires": {
-                "arr-diff": "^2.0.0",
-                "array-unique": "^0.2.1",
-                "braces": "^1.8.2",
-                "expand-brackets": "^0.1.4",
-                "extglob": "^0.3.1",
-                "filename-regex": "^2.0.0",
-                "is-extglob": "^1.0.0",
-                "is-glob": "^2.0.1",
-                "kind-of": "^3.0.2",
-                "normalize-path": "^2.0.1",
-                "object.omit": "^2.0.0",
-                "parse-glob": "^3.0.4",
-                "regex-cache": "^0.4.2"
+                "arr-diff": "^4.0.0",
+                "array-unique": "^0.3.2",
+                "braces": "^2.3.1",
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "extglob": "^2.0.4",
+                "fragment-cache": "^0.2.1",
+                "kind-of": "^6.0.2",
+                "nanomatch": "^1.2.9",
+                "object.pick": "^1.3.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.2"
+            },
+            "dependencies": {
+                "extend-shallow": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+                    "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+                    "requires": {
+                        "assign-symbols": "^1.0.0",
+                        "is-extendable": "^1.0.1"
+                    }
+                },
+                "is-extendable": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+                    "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+                    "requires": {
+                        "is-plain-object": "^2.0.4"
+                    }
+                },
+                "kind-of": {
+                    "version": "6.0.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+                    "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+                }
             }
         },
         "miller-rabin": {
@@ -4998,17 +5136,12 @@
             "dev": true
         },
         "minimatch": {
-            "version": "2.0.10",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-            "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
             "requires": {
-                "brace-expansion": "^1.0.0"
+                "brace-expansion": "^1.1.7"
             }
-        },
-        "minimist": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-            "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         },
         "mississippi": {
             "version": "2.0.0",
@@ -5052,7 +5185,6 @@
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
             "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
-            "dev": true,
             "requires": {
                 "for-in": "^1.0.2",
                 "is-extendable": "^1.0.1"
@@ -5062,7 +5194,6 @@
                     "version": "1.0.1",
                     "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-                    "dev": true,
                     "requires": {
                         "is-plain-object": "^2.0.4"
                     }
@@ -5073,6 +5204,7 @@
             "version": "0.5.1",
             "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
             "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+            "dev": true,
             "requires": {
                 "minimist": "0.0.8"
             },
@@ -5080,7 +5212,8 @@
                 "minimist": {
                     "version": "0.0.8",
                     "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                    "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+                    "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+                    "dev": true
                 }
             }
         },
@@ -5101,29 +5234,23 @@
         "ms": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-            "dev": true
+            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         },
-        "multipipe": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
-            "integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
-            "requires": {
-                "duplexer2": "0.0.2"
-            }
+        "mute-stdout": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/mute-stdout/-/mute-stdout-1.0.1.tgz",
+            "integrity": "sha512-kDcwXR4PS7caBpuRYYBUz9iVixUk3anO3f5OYFiIPwK/20vCzKCHyKoulbiDY1S53zD2bxUpxN/IJ+TnXjfvxg=="
         },
         "nan": {
             "version": "2.10.0",
             "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
             "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
-            "dev": true,
             "optional": true
         },
         "nanomatch": {
             "version": "1.2.13",
             "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
             "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
-            "dev": true,
             "requires": {
                 "arr-diff": "^4.0.0",
                 "array-unique": "^0.3.2",
@@ -5141,20 +5268,17 @@
                 "arr-diff": {
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-                    "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
-                    "dev": true
+                    "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
                 },
                 "array-unique": {
                     "version": "0.3.2",
                     "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-                    "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-                    "dev": true
+                    "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
                 },
                 "extend-shallow": {
                     "version": "3.0.2",
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
                     "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
-                    "dev": true,
                     "requires": {
                         "assign-symbols": "^1.0.0",
                         "is-extendable": "^1.0.1"
@@ -5164,7 +5288,6 @@
                     "version": "1.0.1",
                     "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-                    "dev": true,
                     "requires": {
                         "is-plain-object": "^2.0.4"
                     }
@@ -5172,36 +5295,27 @@
                 "is-windows": {
                     "version": "1.0.2",
                     "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-                    "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
-                    "dev": true
+                    "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
                 },
                 "isobject": {
                     "version": "3.0.1",
                     "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-                    "dev": true
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
                 },
                 "kind-of": {
                     "version": "6.0.2",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-                    "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-                    "dev": true
+                    "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
                 },
                 "object.pick": {
                     "version": "1.3.0",
                     "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
                     "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
-                    "dev": true,
                     "requires": {
                         "isobject": "^3.0.1"
                     }
                 }
             }
-        },
-        "natives": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.0.tgz",
-            "integrity": "sha1-6f+EFBimsux6SV6TmYT3jxY+bjE="
         },
         "natural-compare": {
             "version": "1.4.0",
@@ -5214,6 +5328,11 @@
             "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.5.1.tgz",
             "integrity": "sha512-3KL3fvuRkZ7s4IFOMfztb7zJp3QaVWnBeGoJlgB38XnCRPj/0tLzzLG5IB8NYOHbJ8g8UGrgZv44GLDk6CxTxA==",
             "dev": true
+        },
+        "next-tick": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+            "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
         },
         "nice-try": {
             "version": "1.0.4",
@@ -5300,7 +5419,6 @@
             "version": "2.4.0",
             "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
             "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
-            "dev": true,
             "requires": {
                 "hosted-git-info": "^2.1.4",
                 "is-builtin-module": "^1.0.0",
@@ -5316,16 +5434,23 @@
                 "remove-trailing-separator": "^1.0.1"
             }
         },
-        "object-assign": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
-            "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
+        "now-and-later": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/now-and-later/-/now-and-later-2.0.0.tgz",
+            "integrity": "sha1-vGHLtFbXnLMiB85HygUTb/Ln1u4=",
+            "requires": {
+                "once": "^1.3.2"
+            }
+        },
+        "number-is-nan": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+            "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
         },
         "object-copy": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
             "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
-            "dev": true,
             "requires": {
                 "copy-descriptor": "^0.1.0",
                 "define-property": "^0.2.5",
@@ -5336,7 +5461,6 @@
                     "version": "0.2.5",
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-                    "dev": true,
                     "requires": {
                         "is-descriptor": "^0.1.0"
                     }
@@ -5346,14 +5470,12 @@
         "object-keys": {
             "version": "1.0.12",
             "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
-            "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==",
-            "dev": true
+            "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag=="
         },
         "object-visit": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
             "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
-            "dev": true,
             "requires": {
                 "isobject": "^3.0.0"
             },
@@ -5361,9 +5483,19 @@
                 "isobject": {
                     "version": "3.0.1",
                     "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-                    "dev": true
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
                 }
+            }
+        },
+        "object.assign": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+            "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+            "requires": {
+                "define-properties": "^1.1.2",
+                "function-bind": "^1.1.1",
+                "has-symbols": "^1.0.0",
+                "object-keys": "^1.0.11"
             }
         },
         "object.defaults": {
@@ -5375,38 +5507,32 @@
                 "array-slice": "^1.0.0",
                 "for-own": "^1.0.0",
                 "isobject": "^3.0.0"
-            },
-            "dependencies": {
-                "for-own": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
-                    "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
-                    "requires": {
-                        "for-in": "^1.0.1"
-                    }
-                },
-                "isobject": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-                }
             }
         },
-        "object.omit": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-            "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+        "object.map": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/object.map/-/object.map-1.0.1.tgz",
+            "integrity": "sha1-z4Plncj8wK1fQlDh94s7gb2AHTc=",
             "requires": {
-                "for-own": "^0.1.4",
-                "is-extendable": "^0.1.1"
+                "for-own": "^1.0.0",
+                "make-iterator": "^1.0.0"
             }
         },
         "object.pick": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.2.0.tgz",
-            "integrity": "sha1-tTkr7peC2m2ft9avr1OXefEjTCs=",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+            "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
             "requires": {
-                "isobject": "^2.1.0"
+                "isobject": "^3.0.1"
+            }
+        },
+        "object.reduce": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/object.reduce/-/object.reduce-1.0.1.tgz",
+            "integrity": "sha1-b+NI8qx/oPlcpiEiZZkJaCW7A60=",
+            "requires": {
+                "for-own": "^1.0.0",
+                "make-iterator": "^1.0.0"
             }
         },
         "once": {
@@ -5431,20 +5557,47 @@
                 "wordwrap": "~1.0.0"
             }
         },
-        "orchestrator": {
-            "version": "0.3.8",
-            "resolved": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.8.tgz",
-            "integrity": "sha1-FOfp4nZPcxX7rBhOUGx6pt+UrX4=",
-            "requires": {
-                "end-of-stream": "~0.1.5",
-                "sequencify": "~0.0.7",
-                "stream-consume": "~0.1.0"
-            }
-        },
         "ordered-read-streams": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz",
-            "integrity": "sha1-/VZamvjrRHO6abbtijQ1LLVS8SY="
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-1.0.1.tgz",
+            "integrity": "sha1-d8DLN8QVJdZBZtmQ/61+xqDhNj4=",
+            "requires": {
+                "readable-stream": "^2.0.1"
+            },
+            "dependencies": {
+                "isarray": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+                },
+                "process-nextick-args": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+                    "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+                },
+                "readable-stream": {
+                    "version": "2.3.6",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+                    "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                    "requires": {
+                        "safe-buffer": "~5.1.0"
+                    }
+                }
+            }
         },
         "os-browserify": {
             "version": "0.3.0",
@@ -5452,10 +5605,13 @@
             "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
             "dev": true
         },
-        "os-homedir": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-            "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+        "os-locale": {
+            "version": "1.4.0",
+            "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+            "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+            "requires": {
+                "lcid": "^1.0.0"
+            }
         },
         "os-tmpdir": {
             "version": "1.0.2",
@@ -5556,31 +5712,19 @@
             }
         },
         "parse-filepath": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.1.tgz",
-            "integrity": "sha1-FZ1hVdQ5BNFsEO9piRHaHpGWm3M=",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.2.tgz",
+            "integrity": "sha1-pjISf1Oq89FYdvWHLz/6x2PWyJE=",
             "requires": {
-                "is-absolute": "^0.2.3",
+                "is-absolute": "^1.0.0",
                 "map-cache": "^0.2.0",
                 "path-root": "^0.1.1"
-            }
-        },
-        "parse-glob": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-            "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-            "requires": {
-                "glob-base": "^0.3.0",
-                "is-dotfile": "^1.0.0",
-                "is-extglob": "^1.0.0",
-                "is-glob": "^2.0.0"
             }
         },
         "parse-json": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
             "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-            "dev": true,
             "requires": {
                 "error-ex": "^1.2.0"
             }
@@ -5593,8 +5737,7 @@
         "pascalcase": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
-            "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
-            "dev": true
+            "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
         },
         "path-browserify": {
             "version": "0.0.0",
@@ -5605,14 +5748,12 @@
         "path-dirname": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
-            "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
-            "dev": true
+            "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA="
         },
         "path-exists": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
             "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-            "dev": true,
             "requires": {
                 "pinkie-promise": "^2.0.0"
             }
@@ -5620,8 +5761,7 @@
         "path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-            "dev": true
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
         },
         "path-is-inside": {
             "version": "1.0.2",
@@ -5678,20 +5818,17 @@
         "pify": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-            "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-            "dev": true
+            "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
         },
         "pinkie": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-            "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-            "dev": true
+            "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
         },
         "pinkie-promise": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
             "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-            "dev": true,
             "requires": {
                 "pinkie": "^2.0.0"
             }
@@ -5736,19 +5873,13 @@
         "posix-character-classes": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
-            "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
-            "dev": true
+            "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
         },
         "prelude-ls": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
             "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
             "dev": true
-        },
-        "preserve": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-            "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
         },
         "prettier": {
             "version": "1.14.0",
@@ -5825,7 +5956,6 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
             "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
-            "dev": true,
             "requires": {
                 "end-of-stream": "^1.1.0",
                 "once": "^1.3.1"
@@ -5835,7 +5965,6 @@
                     "version": "1.4.1",
                     "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
                     "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
-                    "dev": true,
                     "requires": {
                         "once": "^1.4.0"
                     },
@@ -5844,7 +5973,6 @@
                             "version": "1.4.0",
                             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
                             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-                            "dev": true,
                             "requires": {
                                 "wrappy": "1"
                             }
@@ -5857,7 +5985,6 @@
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
             "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
-            "dev": true,
             "requires": {
                 "duplexify": "^3.6.0",
                 "inherits": "^2.0.3",
@@ -5881,43 +6008,6 @@
             "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
             "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
             "dev": true
-        },
-        "randomatic": {
-            "version": "1.1.7",
-            "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
-            "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
-            "requires": {
-                "is-number": "^3.0.0",
-                "kind-of": "^4.0.0"
-            },
-            "dependencies": {
-                "is-number": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-                    "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-                    "requires": {
-                        "kind-of": "^3.0.2"
-                    },
-                    "dependencies": {
-                        "kind-of": {
-                            "version": "3.2.2",
-                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                            "requires": {
-                                "is-buffer": "^1.1.5"
-                            }
-                        }
-                    }
-                },
-                "kind-of": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-                    "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-                    "requires": {
-                        "is-buffer": "^1.1.5"
-                    }
-                }
-            }
         },
         "randombytes": {
             "version": "2.0.6",
@@ -5974,6 +6064,7 @@
             "version": "1.1.14",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
             "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+            "dev": true,
             "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.1",
@@ -5985,7 +6076,6 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
             "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
-            "dev": true,
             "requires": {
                 "graceful-fs": "^4.1.2",
                 "minimatch": "^3.0.2",
@@ -5996,20 +6086,17 @@
                 "graceful-fs": {
                     "version": "4.1.11",
                     "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-                    "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-                    "dev": true
+                    "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
                 },
                 "isarray": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-                    "dev": true
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
                 },
                 "minimatch": {
                     "version": "3.0.4",
                     "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
                     "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-                    "dev": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
                     }
@@ -6017,14 +6104,12 @@
                 "process-nextick-args": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-                    "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
-                    "dev": true
+                    "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
                 },
                 "readable-stream": {
                     "version": "2.3.6",
                     "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-                    "dev": true,
                     "requires": {
                         "core-util-is": "~1.0.0",
                         "inherits": "~2.0.3",
@@ -6039,7 +6124,6 @@
                     "version": "1.1.1",
                     "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-                    "dev": true,
                     "requires": {
                         "safe-buffer": "~5.1.0"
                     }
@@ -6054,20 +6138,10 @@
                 "resolve": "^1.1.6"
             }
         },
-        "regex-cache": {
-            "version": "0.4.3",
-            "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
-            "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
-            "requires": {
-                "is-equal-shallow": "^0.1.3",
-                "is-primitive": "^2.0.0"
-            }
-        },
         "regex-not": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
             "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
-            "dev": true,
             "requires": {
                 "extend-shallow": "^3.0.2",
                 "safe-regex": "^1.1.0"
@@ -6077,7 +6151,6 @@
                     "version": "3.0.2",
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
                     "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
-                    "dev": true,
                     "requires": {
                         "assign-symbols": "^1.0.0",
                         "is-extendable": "^1.0.1"
@@ -6087,7 +6160,6 @@
                     "version": "1.0.1",
                     "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-                    "dev": true,
                     "requires": {
                         "is-plain-object": "^2.0.4"
                     }
@@ -6109,6 +6181,25 @@
             "integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw==",
             "dev": true
         },
+        "remove-bom-buffer": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/remove-bom-buffer/-/remove-bom-buffer-3.0.0.tgz",
+            "integrity": "sha512-8v2rWhaakv18qcvNeli2mZ/TMTL2nEyAKRvzo1WtnZBl15SHyEhrCu2/xKlJyUFKHiHgfXIyuY6g2dObJJycXQ==",
+            "requires": {
+                "is-buffer": "^1.1.5",
+                "is-utf8": "^0.2.1"
+            }
+        },
+        "remove-bom-stream": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/remove-bom-stream/-/remove-bom-stream-1.2.0.tgz",
+            "integrity": "sha1-BfGlk/FuQuH7kOv1nejlaVJflSM=",
+            "requires": {
+                "remove-bom-buffer": "^3.0.0",
+                "safe-buffer": "^5.1.0",
+                "through2": "^2.0.3"
+            }
+        },
         "remove-trailing-separator": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz",
@@ -6125,9 +6216,36 @@
             "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
         },
         "replace-ext": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
-            "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+            "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
+        },
+        "replace-homedir": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/replace-homedir/-/replace-homedir-1.0.0.tgz",
+            "integrity": "sha1-6H9tUTuSjd6AgmDBK+f+xv9ueYw=",
+            "requires": {
+                "homedir-polyfill": "^1.0.1",
+                "is-absolute": "^1.0.0",
+                "remove-trailing-separator": "^1.1.0"
+            },
+            "dependencies": {
+                "remove-trailing-separator": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+                    "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
+                }
+            }
+        },
+        "require-directory": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+            "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+        },
+        "require-main-filename": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+            "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
         },
         "require-uncached": {
             "version": "1.0.3",
@@ -6148,12 +6266,12 @@
             }
         },
         "resolve-dir": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
-            "integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4=",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
+            "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
             "requires": {
-                "expand-tilde": "^1.2.2",
-                "global-modules": "^0.2.3"
+                "expand-tilde": "^2.0.0",
+                "global-modules": "^1.0.0"
             }
         },
         "resolve-from": {
@@ -6162,17 +6280,23 @@
             "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
             "dev": true
         },
+        "resolve-options": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/resolve-options/-/resolve-options-1.1.0.tgz",
+            "integrity": "sha1-MrueOcBtZzONyTeMDW1gdFZq0TE=",
+            "requires": {
+                "value-or-function": "^3.0.0"
+            }
+        },
         "resolve-url": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-            "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
-            "dev": true
+            "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
         },
         "ret": {
             "version": "0.1.15",
             "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
-            "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
-            "dev": true
+            "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
         },
         "rimraf": {
             "version": "2.6.1",
@@ -6245,7 +6369,6 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
             "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
-            "dev": true,
             "requires": {
                 "ret": "~0.1.10"
             }
@@ -6277,10 +6400,13 @@
             "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
             "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto="
         },
-        "sequencify": {
-            "version": "0.0.7",
-            "resolved": "https://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz",
-            "integrity": "sha1-kM/xnQLgcCf9dn9erT57ldHnOAw="
+        "semver-greatest-satisfied-range": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/semver-greatest-satisfied-range/-/semver-greatest-satisfied-range-1.1.0.tgz",
+            "integrity": "sha1-E+jCZYq5aRywzXEJMkAoDTb3els=",
+            "requires": {
+                "sver-compat": "^1.5.0"
+            }
         },
         "serialize-javascript": {
             "version": "1.5.0",
@@ -6288,17 +6414,20 @@
             "integrity": "sha512-Ga8c8NjAAp46Br4+0oZ2WxJCwIzwP60Gq1YPgU+39PiTVxyed/iKE/zyZI6+UlVYH5Q4PaQdHhcegIFPZTUfoQ==",
             "dev": true
         },
+        "set-blocking": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+            "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+        },
         "set-immediate-shim": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-            "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
-            "dev": true
+            "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
         },
         "set-value": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
             "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
-            "dev": true,
             "requires": {
                 "extend-shallow": "^2.0.1",
                 "is-extendable": "^0.1.1",
@@ -6310,7 +6439,6 @@
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                    "dev": true,
                     "requires": {
                         "is-extendable": "^0.1.0"
                     }
@@ -6348,11 +6476,6 @@
             "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
             "dev": true
         },
-        "sigmund": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-            "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA="
-        },
         "signal-exit": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
@@ -6363,7 +6486,6 @@
             "version": "0.8.2",
             "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
             "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
-            "dev": true,
             "requires": {
                 "base": "^0.11.1",
                 "debug": "^2.2.0",
@@ -6379,7 +6501,6 @@
                     "version": "2.6.9",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
                     "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-                    "dev": true,
                     "requires": {
                         "ms": "2.0.0"
                     }
@@ -6388,7 +6509,6 @@
                     "version": "0.2.5",
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-                    "dev": true,
                     "requires": {
                         "is-descriptor": "^0.1.0"
                     }
@@ -6397,7 +6517,6 @@
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                    "dev": true,
                     "requires": {
                         "is-extendable": "^0.1.0"
                     }
@@ -6408,7 +6527,6 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
             "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
-            "dev": true,
             "requires": {
                 "define-property": "^1.0.0",
                 "isobject": "^3.0.0",
@@ -6419,7 +6537,6 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-                    "dev": true,
                     "requires": {
                         "is-descriptor": "^1.0.0"
                     }
@@ -6428,7 +6545,6 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-                    "dev": true,
                     "requires": {
                         "kind-of": "^6.0.0"
                     }
@@ -6437,7 +6553,6 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-                    "dev": true,
                     "requires": {
                         "kind-of": "^6.0.0"
                     }
@@ -6446,7 +6561,6 @@
                     "version": "1.0.2",
                     "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-                    "dev": true,
                     "requires": {
                         "is-accessor-descriptor": "^1.0.0",
                         "is-data-descriptor": "^1.0.0",
@@ -6456,14 +6570,12 @@
                 "isobject": {
                     "version": "3.0.1",
                     "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-                    "dev": true
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
                 },
                 "kind-of": {
                     "version": "6.0.2",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-                    "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-                    "dev": true
+                    "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
                 }
             }
         },
@@ -6471,7 +6583,6 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
             "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
-            "dev": true,
             "requires": {
                 "kind-of": "^3.2.0"
             }
@@ -6485,14 +6596,12 @@
         "source-map": {
             "version": "0.5.7",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-            "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-            "dev": true
+            "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         },
         "source-map-resolve": {
             "version": "0.5.2",
             "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
             "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
-            "dev": true,
             "requires": {
                 "atob": "^2.1.1",
                 "decode-uri-component": "^0.2.0",
@@ -6504,19 +6613,17 @@
         "source-map-url": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
-            "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
-            "dev": true
+            "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
         },
         "sparkles": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
-            "integrity": "sha1-Gsu/tZJDbRC76PeFt8xvgoFQEsM="
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.1.tgz",
+            "integrity": "sha512-dSO0DDYUahUt/0/pD/Is3VIm5TGJjludZ0HVymmhYF6eNA53PVLhnUk0znSYbH8IYBuJdCE+1luR22jNLMaQdw=="
         },
         "spdx-correct": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
             "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
-            "dev": true,
             "requires": {
                 "spdx-expression-parse": "^3.0.0",
                 "spdx-license-ids": "^3.0.0"
@@ -6525,14 +6632,12 @@
         "spdx-exceptions": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
-            "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
-            "dev": true
+            "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg=="
         },
         "spdx-expression-parse": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
             "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
-            "dev": true,
             "requires": {
                 "spdx-exceptions": "^2.1.0",
                 "spdx-license-ids": "^3.0.0"
@@ -6541,14 +6646,12 @@
         "spdx-license-ids": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
-            "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==",
-            "dev": true
+            "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA=="
         },
         "split-string": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
             "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
-            "dev": true,
             "requires": {
                 "extend-shallow": "^3.0.0"
             },
@@ -6557,7 +6660,6 @@
                     "version": "3.0.2",
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
                     "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
-                    "dev": true,
                     "requires": {
                         "assign-symbols": "^1.0.0",
                         "is-extendable": "^1.0.1"
@@ -6567,7 +6669,6 @@
                     "version": "1.0.1",
                     "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-                    "dev": true,
                     "requires": {
                         "is-plain-object": "^2.0.4"
                     }
@@ -6589,11 +6690,15 @@
                 "safe-buffer": "^5.1.1"
             }
         },
+        "stack-trace": {
+            "version": "0.0.10",
+            "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+            "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
+        },
         "static-extend": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
             "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
-            "dev": true,
             "requires": {
                 "define-property": "^0.2.5",
                 "object-copy": "^0.1.0"
@@ -6603,7 +6708,6 @@
                     "version": "0.2.5",
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-                    "dev": true,
                     "requires": {
                         "is-descriptor": "^0.1.0"
                     }
@@ -6658,11 +6762,6 @@
                 }
             }
         },
-        "stream-consume": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.0.tgz",
-            "integrity": "sha1-pB6tGm1ggc63n2WwYZAbbY89HQ8="
-        },
         "stream-each": {
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.2.tgz",
@@ -6692,6 +6791,11 @@
                     }
                 }
             }
+        },
+        "stream-exhaust": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/stream-exhaust/-/stream-exhaust-1.0.2.tgz",
+            "integrity": "sha512-b/qaq/GlBK5xaq1yrK9/zFcyRSTNxmcZwFLGSTG0mXgZl/4Z6GgiyYOXOvY7N3eEvFRAG1bkDRz5EPGSvPYQlw=="
         },
         "stream-http": {
             "version": "2.8.3",
@@ -6747,8 +6851,17 @@
         "stream-shift": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
-            "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
-            "dev": true
+            "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
+        },
+        "string-width": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+            "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+            "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+            }
         },
         "string.prototype.matchall": {
             "version": "2.0.0",
@@ -6766,7 +6879,8 @@
         "string_decoder": {
             "version": "0.10.31",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-            "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+            "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+            "dev": true
         },
         "strip-ansi": {
             "version": "3.0.1",
@@ -6777,11 +6891,10 @@
             }
         },
         "strip-bom": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
-            "integrity": "sha1-hbiGLzhEtabV7IRnqTWYFzo295Q=",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+            "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
             "requires": {
-                "first-chunk-stream": "^1.0.0",
                 "is-utf8": "^0.2.0"
             }
         },
@@ -6794,7 +6907,17 @@
         "supports-color": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-            "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+            "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+            "dev": true
+        },
+        "sver-compat": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/sver-compat/-/sver-compat-1.5.0.tgz",
+            "integrity": "sha1-PPh9/rTQe0o/FIJ7wYaz/QxkXNg=",
+            "requires": {
+                "es6-iterator": "^2.0.1",
+                "es6-symbol": "^3.1.1"
+            }
         },
         "symbol-observable": {
             "version": "1.0.1",
@@ -6858,12 +6981,13 @@
                 }
             }
         },
-        "tildify": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/tildify/-/tildify-1.2.0.tgz",
-            "integrity": "sha1-3OwD9V3Km3qj5bBPIYF+tW5jWIo=",
+        "through2-filter": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
+            "integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
             "requires": {
-                "os-homedir": "^1.0.0"
+                "through2": "~2.0.0",
+                "xtend": "~4.0.0"
             }
         },
         "time-stamp": {
@@ -6889,6 +7013,15 @@
                 "os-tmpdir": "~1.0.2"
             }
         },
+        "to-absolute-glob": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
+            "integrity": "sha1-GGX0PZ50sIItufFFt4z/fQ98hJs=",
+            "requires": {
+                "is-absolute": "^1.0.0",
+                "is-negated-glob": "^1.0.0"
+            }
+        },
         "to-arraybuffer": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
@@ -6905,7 +7038,6 @@
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
             "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
-            "dev": true,
             "requires": {
                 "kind-of": "^3.0.2"
             }
@@ -6914,7 +7046,6 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
             "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
-            "dev": true,
             "requires": {
                 "define-property": "^2.0.2",
                 "extend-shallow": "^3.0.2",
@@ -6926,7 +7057,6 @@
                     "version": "3.0.2",
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
                     "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
-                    "dev": true,
                     "requires": {
                         "assign-symbols": "^1.0.0",
                         "is-extendable": "^1.0.1"
@@ -6936,7 +7066,6 @@
                     "version": "1.0.1",
                     "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-                    "dev": true,
                     "requires": {
                         "is-plain-object": "^2.0.4"
                     }
@@ -6947,7 +7076,6 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
             "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
-            "dev": true,
             "requires": {
                 "is-number": "^3.0.0",
                 "repeat-string": "^1.6.1"
@@ -6957,11 +7085,18 @@
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-                    "dev": true,
                     "requires": {
                         "kind-of": "^3.0.2"
                     }
                 }
+            }
+        },
+        "to-through": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/to-through/-/to-through-2.0.0.tgz",
+            "integrity": "sha1-/JKtq6ByZHvAtn1rA2ZKoZUJOvY=",
+            "requires": {
+                "through2": "^2.0.3"
             }
         },
         "trim-right": {
@@ -6994,8 +7129,7 @@
         "typedarray": {
             "version": "0.0.6",
             "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-            "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-            "dev": true
+            "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
         },
         "uglify-es": {
             "version": "3.3.9",
@@ -7056,11 +7190,31 @@
             "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
             "dev": true
         },
+        "undertaker": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/undertaker/-/undertaker-1.2.0.tgz",
+            "integrity": "sha1-M52kZGJS0ILcN45wgGcpl1DhG0k=",
+            "requires": {
+                "arr-flatten": "^1.0.1",
+                "arr-map": "^2.0.0",
+                "bach": "^1.0.0",
+                "collection-map": "^1.0.0",
+                "es6-weak-map": "^2.0.1",
+                "last-run": "^1.1.0",
+                "object.defaults": "^1.0.0",
+                "object.reduce": "^1.0.0",
+                "undertaker-registry": "^1.0.0"
+            }
+        },
+        "undertaker-registry": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/undertaker-registry/-/undertaker-registry-1.0.1.tgz",
+            "integrity": "sha1-XkvaMI5KiirlhPm5pDWaSZglzFA="
+        },
         "union-value": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
             "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
-            "dev": true,
             "requires": {
                 "arr-union": "^3.1.0",
                 "get-value": "^2.0.6",
@@ -7071,14 +7225,12 @@
                 "arr-union": {
                     "version": "3.1.0",
                     "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-                    "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
-                    "dev": true
+                    "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
                 },
                 "extend-shallow": {
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                    "dev": true,
                     "requires": {
                         "is-extendable": "^0.1.0"
                     }
@@ -7087,7 +7239,6 @@
                     "version": "0.4.3",
                     "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
                     "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-                    "dev": true,
                     "requires": {
                         "extend-shallow": "^2.0.1",
                         "is-extendable": "^0.1.1",
@@ -7116,15 +7267,18 @@
             }
         },
         "unique-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz",
-            "integrity": "sha1-1ZpKdUJ0R9mqbJHnAmP40mpLEEs="
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
+            "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
+            "requires": {
+                "json-stable-stringify": "^1.0.0",
+                "through2-filter": "^2.0.0"
+            }
         },
         "unset-value": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
             "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
-            "dev": true,
             "requires": {
                 "has-value": "^0.3.1",
                 "isobject": "^3.0.0"
@@ -7134,7 +7288,6 @@
                     "version": "0.3.1",
                     "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
                     "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
-                    "dev": true,
                     "requires": {
                         "get-value": "^2.0.3",
                         "has-values": "^0.1.4",
@@ -7145,7 +7298,6 @@
                             "version": "2.1.0",
                             "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
                             "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-                            "dev": true,
                             "requires": {
                                 "isarray": "1.0.0"
                             }
@@ -7155,28 +7307,24 @@
                 "has-values": {
                     "version": "0.1.4",
                     "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
-                    "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
-                    "dev": true
+                    "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
                 },
                 "isarray": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-                    "dev": true
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
                 },
                 "isobject": {
                     "version": "3.0.1",
                     "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-                    "dev": true
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
                 }
             }
         },
         "upath": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/upath/-/upath-1.1.0.tgz",
-            "integrity": "sha512-bzpH/oBhoS/QI/YtbkqCg6VEiPYjSZtrHQM6/QnJS6OL9pKUFLqb3aFh4Scvwm45+7iAgiMkLhSbaZxUqmrprw==",
-            "dev": true
+            "integrity": "sha512-bzpH/oBhoS/QI/YtbkqCg6VEiPYjSZtrHQM6/QnJS6OL9pKUFLqb3aFh4Scvwm45+7iAgiMkLhSbaZxUqmrprw=="
         },
         "uri-js": {
             "version": "4.2.2",
@@ -7190,8 +7338,7 @@
         "urix": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-            "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
-            "dev": true
+            "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
         },
         "url": {
             "version": "0.11.0",
@@ -7214,13 +7361,7 @@
         "use": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
-            "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
-            "dev": true
-        },
-        "user-home": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-            "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA="
+            "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
         },
         "util": {
             "version": "0.10.4",
@@ -7237,82 +7378,110 @@
             "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
         },
         "v8flags": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
-            "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.1.1.tgz",
+            "integrity": "sha512-iw/1ViSEaff8NJ3HLyEjawk/8hjJib3E7pvG4pddVXfUg1983s3VGsiClDjhK64MQVDGqc1Q8r18S4VKQZS9EQ==",
             "requires": {
-                "user-home": "^1.1.1"
+                "homedir-polyfill": "^1.0.1"
             }
         },
         "validate-npm-package-license": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
             "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
-            "dev": true,
             "requires": {
                 "spdx-correct": "^3.0.0",
                 "spdx-expression-parse": "^3.0.0"
             }
         },
+        "value-or-function": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/value-or-function/-/value-or-function-3.0.0.tgz",
+            "integrity": "sha1-HCQ6ULWVwb5Up1S/7OhWO5/42BM="
+        },
         "vinyl": {
-            "version": "0.5.3",
-            "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
-            "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
+            "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
             "requires": {
-                "clone": "^1.0.0",
-                "clone-stats": "^0.0.1",
-                "replace-ext": "0.0.1"
+                "clone": "^2.1.1",
+                "clone-buffer": "^1.0.0",
+                "clone-stats": "^1.0.0",
+                "cloneable-readable": "^1.0.0",
+                "remove-trailing-separator": "^1.0.1",
+                "replace-ext": "^1.0.0"
             }
         },
         "vinyl-fs": {
-            "version": "0.3.14",
-            "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.14.tgz",
-            "integrity": "sha1-mmhRzhysHBzqX+hsCTHWIMLPqeY=",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-3.0.3.tgz",
+            "integrity": "sha512-vIu34EkyNyJxmP0jscNzWBSygh7VWhqun6RmqVfXePrOwi9lhvRs//dOaGOTRUQr4tx7/zd26Tk5WeSVZitgng==",
             "requires": {
-                "defaults": "^1.0.0",
-                "glob-stream": "^3.1.5",
-                "glob-watcher": "^0.0.6",
-                "graceful-fs": "^3.0.0",
-                "mkdirp": "^0.5.0",
-                "strip-bom": "^1.0.0",
-                "through2": "^0.6.1",
-                "vinyl": "^0.4.0"
+                "fs-mkdirp-stream": "^1.0.0",
+                "glob-stream": "^6.1.0",
+                "graceful-fs": "^4.0.0",
+                "is-valid-glob": "^1.0.0",
+                "lazystream": "^1.0.0",
+                "lead": "^1.0.0",
+                "object.assign": "^4.0.4",
+                "pumpify": "^1.3.5",
+                "readable-stream": "^2.3.3",
+                "remove-bom-buffer": "^3.0.0",
+                "remove-bom-stream": "^1.2.0",
+                "resolve-options": "^1.1.0",
+                "through2": "^2.0.0",
+                "to-through": "^2.0.0",
+                "value-or-function": "^3.0.0",
+                "vinyl": "^2.0.0",
+                "vinyl-sourcemap": "^1.1.0"
             },
             "dependencies": {
-                "clone": {
-                    "version": "0.2.0",
-                    "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
-                    "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8="
+                "isarray": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+                },
+                "process-nextick-args": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+                    "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
                 },
                 "readable-stream": {
-                    "version": "1.0.34",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-                    "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+                    "version": "2.3.6",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+                    "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "requires": {
                         "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.1",
-                        "isarray": "0.0.1",
-                        "string_decoder": "~0.10.x"
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
                     }
                 },
-                "through2": {
-                    "version": "0.6.5",
-                    "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-                    "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+                "string_decoder": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "requires": {
-                        "readable-stream": ">=1.0.33-1 <1.1.0-0",
-                        "xtend": ">=4.0.0 <4.1.0-0"
-                    }
-                },
-                "vinyl": {
-                    "version": "0.4.6",
-                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
-                    "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
-                    "requires": {
-                        "clone": "^0.2.0",
-                        "clone-stats": "^0.0.1"
+                        "safe-buffer": "~5.1.0"
                     }
                 }
+            }
+        },
+        "vinyl-sourcemap": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/vinyl-sourcemap/-/vinyl-sourcemap-1.1.0.tgz",
+            "integrity": "sha1-kqgAWTo4cDqM2xHYswCtS+Y7PhY=",
+            "requires": {
+                "append-buffer": "^1.0.2",
+                "convert-source-map": "^1.5.0",
+                "graceful-fs": "^4.1.6",
+                "normalize-path": "^2.1.1",
+                "now-and-later": "^2.0.0",
+                "remove-bom-buffer": "^3.0.0",
+                "vinyl": "^2.0.0"
             }
         },
         "vm-browserify": {
@@ -7792,6 +7961,11 @@
                 "isexe": "^2.0.0"
             }
         },
+        "which-module": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+            "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
+        },
         "wordwrap": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
@@ -7805,6 +7979,15 @@
             "dev": true,
             "requires": {
                 "errno": "~0.1.7"
+            }
+        },
+        "wrap-ansi": {
+            "version": "2.1.0",
+            "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+            "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+            "requires": {
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1"
             }
         },
         "wrappy": {
@@ -7853,6 +8036,82 @@
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
             "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
             "dev": true
+        },
+        "yargs": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
+            "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
+            "requires": {
+                "camelcase": "^3.0.0",
+                "cliui": "^3.2.0",
+                "decamelize": "^1.1.1",
+                "get-caller-file": "^1.0.1",
+                "os-locale": "^1.4.0",
+                "read-pkg-up": "^1.0.1",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^1.0.1",
+                "set-blocking": "^2.0.0",
+                "string-width": "^1.0.2",
+                "which-module": "^1.0.0",
+                "y18n": "^3.2.1",
+                "yargs-parser": "^5.0.0"
+            },
+            "dependencies": {
+                "load-json-file": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+                    "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+                    "requires": {
+                        "graceful-fs": "^4.1.2",
+                        "parse-json": "^2.2.0",
+                        "pify": "^2.0.0",
+                        "pinkie-promise": "^2.0.0",
+                        "strip-bom": "^2.0.0"
+                    }
+                },
+                "path-type": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+                    "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+                    "requires": {
+                        "graceful-fs": "^4.1.2",
+                        "pify": "^2.0.0",
+                        "pinkie-promise": "^2.0.0"
+                    }
+                },
+                "read-pkg": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+                    "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+                    "requires": {
+                        "load-json-file": "^1.0.0",
+                        "normalize-package-data": "^2.3.2",
+                        "path-type": "^1.0.0"
+                    }
+                },
+                "read-pkg-up": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+                    "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+                    "requires": {
+                        "find-up": "^1.0.0",
+                        "read-pkg": "^1.0.0"
+                    }
+                },
+                "y18n": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+                    "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+                }
+            }
+        },
+        "yargs-parser": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
+            "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
+            "requires": {
+                "camelcase": "^3.0.0"
+            }
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "prettier": "^1.14.0"
     },
     "dependencies": {
-        "gulp": "^3.9.1",
+        "gulp": "^4.0.0",
         "plugin-error": "^0.1.2",
         "through2": "^2.0.3"
     },


### PR DESCRIPTION
Resolves issue #31  - seems to be the only thing needed, no code changes were necessary to successfully upgrade gulp system.

The primary reason for upgrading this is to resolve audit security issues with `lodash` and `minimatch`.